### PR TITLE
UHF-2295: TPR url alias fix

### DIFF
--- a/conf/cmi/pathauto.pattern.service_entity_pattern.yml
+++ b/conf/cmi/pathauto.pattern.service_entity_pattern.yml
@@ -7,7 +7,7 @@ dependencies:
 id: service_entity_pattern
 label: 'Service entity pattern'
 type: 'canonical_entities:tpr_service'
-pattern: '[tpr_service:label]'
+pattern: '[tpr_service:menu-link-parents]/[tpr_service:label]'
 selection_criteria: {  }
 selection_logic: and
 weight: 0

--- a/conf/cmi/pathauto.pattern.unit_entity_pattern.yml
+++ b/conf/cmi/pathauto.pattern.unit_entity_pattern.yml
@@ -7,7 +7,7 @@ dependencies:
 id: unit_entity_pattern
 label: 'Unit entity pattern'
 type: 'canonical_entities:tpr_unit'
-pattern: '[tpr_unit:label]'
+pattern: '[tpr_unit:menu-link-parents]/[tpr_unit:label]'
 selection_criteria: {  }
 selection_logic: and
 weight: 0

--- a/conf/cmi/pathauto.settings.yml
+++ b/conf/cmi/pathauto.settings.yml
@@ -1,4 +1,6 @@
 enabled_entity_types:
+  - tpr_service
+  - tpr_unit
   - user
 punctuation:
   double_quotes: 0
@@ -49,5 +51,6 @@ safe_tokens:
   - login-url
   - url
   - url-brief
+  - menu-link-parents
 _core:
   default_config_hash: Ne69dMMwlFhwkLqsxAPs20dQCSMk3iibq1pr5qrHf2I


### PR DESCRIPTION
How to test:

1. Checkout this branch
2. Import the configuration: `make drush-cim`
3. Login to the site as admin
4. See `/admin/config/search/path/settings` and make sure that `menu-link-parents` is listed in the `Safe tokens` field
5. See `/admin/config/search/path/patterns` and make sure that
- `Service entity pattern` is `[tpr_service:menu-link-parents]/[tpr_service:label]`
- `Unit entity pattern` is `[tpr_unit:menu-link-parents]/[tpr_unit:label]`