### PR TITLE
UHF-2700: Enable smartti chat on KYMP

### DIFF
--- a/conf/cmi/block.block.smarttichatbot.yml
+++ b/conf/cmi/block.block.smarttichatbot.yml
@@ -1,0 +1,20 @@
+uuid: cbfb1e61-53cd-4939-94c1-d7f14c397c25
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_platform_config
+  theme:
+    - hdbt
+id: smarttichatbot
+theme: hdbt
+region: attachments
+weight: 0
+provider: null
+plugin: smartti_chatbot
+settings:
+  id: smartti_chatbot
+  label: 'Smartti Chatbot'
+  provider: helfi_platform_config
+  label_display: '0'
+visibility: {  }


### PR DESCRIPTION
How to test:

1. On your instance root `git fetch`
2. `git checkout UHF-2700_enable_smartti_chat_on_kymp`
3. `composer require drupal/helfi_platform_config:dev-UHF-2700_enable_smartti_chat_on_kymp`
4. `make drush-cr`
5. `make drush-cim`
6. `make drush-cr`
7. Go to the site without logging in and if you have accepted the cookies remove them so that the cookie banner pops up on the page. Make sure the chatbot is now not visible over the cookie banner.
8. Once you have accepted the cookies make sure you can see the smartti chatbot everyone on the KYMP instance.

Also check this:
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/168