### PR TITLE
UHF-2787: React and share block

### DIFF
--- a/conf/cmi/block.block.eucookiecomplianceblock.yml
+++ b/conf/cmi/block.block.eucookiecomplianceblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - ctools
     - eu_cookie_compliance
     - system
   theme:
@@ -13,7 +12,7 @@ _core:
 id: eucookiecomplianceblock
 theme: hdbt
 region: after_content
-weight: -7
+weight: -10
 provider: null
 plugin: eu_cookie_compliance_block
 settings:

--- a/conf/cmi/block.block.lowercontentblock.yml
+++ b/conf/cmi/block.block.lowercontentblock.yml
@@ -11,7 +11,7 @@ _core:
 id: lowercontentblock
 theme: hdbt
 region: after_content
-weight: -9
+weight: -11
 provider: null
 plugin: lower_content_block
 settings:

--- a/conf/cmi/block.block.reactandshare.yml
+++ b/conf/cmi/block.block.reactandshare.yml
@@ -9,7 +9,7 @@ dependencies:
 id: reactandshare
 theme: hdbt
 region: after_content
-weight: -8
+weight: -9
 provider: null
 plugin: react_and_share
 settings:

--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -1,3 +1,3 @@
-ignored_config_entities: { }
+ignored_config_entities: {  }
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/conf/cmi/core.entity_form_display.paragraph.accordion.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.accordion.default.yml
@@ -20,6 +20,14 @@ targetEntityType: paragraph
 bundle: accordion
 mode: default
 content:
+  field_accordion_description:
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+    type: text_textarea
+    weight: 3
   field_accordion_design:
     weight: 0
     settings: {  }
@@ -51,14 +59,6 @@ content:
         duplicate: duplicate
     third_party_settings: {  }
     region: content
-  field_accordion_description:
-    region: content
-    settings:
-      placeholder: ''
-      rows: 5
-    third_party_settings: {  }
-    type: text_textarea
-    weight: 3
   field_accordion_title:
     region: content
     settings:

--- a/conf/cmi/helfi_proxy.settings.yml
+++ b/conf/cmi/helfi_proxy.settings.yml
@@ -1,4 +1,4 @@
-asset_path: 'liikenne-assets'
+asset_path: liikenne-assets
 prefixes:
   en: urban-environment-and-traffic
   fi: kaupunkiymparisto-ja-liikenne


### PR DESCRIPTION
How to test:
- Get the local environment up and running
- Run `make drush-cim drush-cr`
- Check that you have the React and share api keys in local.settings.php (if not, ask @teroelonen or @khalima)
- Go to https://helfi-kymp.docker.so/fi/cookie-information-and-settings
   - If you have adblocker on, switch it off for the page to see the React and share block
   - The react and share block should now be in the bottom of the page (after cookie information)
   - ![image](https://user-images.githubusercontent.com/1712902/137466141-56f3e0de-1106-4a76-bbbf-c4417e6bee70.png)
