### PR TITLE
UHF-2921: Mount custom files via docker-compose.yml instead of COPYing them in Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,13 @@ services:
     container_name: "${COMPOSE_PROJECT_NAME}-app"
     image: "${DRUPAL_IMAGE}"
     volumes:
-      - .:/app:delegated
+      - ./docker/local/nginx.conf:/etc/nginx/conf.d/default.conf:cached
+      - ./docker/local/custom.locations:/etc/nginx/conf.d/custom.locations:cached
+      - ./docker/local/php-fpm-pool.conf:/etc/php8/php-fpm.d/www.conf:cached
+      - ./docker/local/entrypoints/30-chromedriver.sh:/entrypoints/30-chromedriver.sh:cached
+      - ./docker/local/entrypoints/30-drush-server.sh:/entrypoints/30-drush-server.sh:cached
       - ssh:/tmp/druid_ssh-agent:ro
+      - .:/app:delegated
     build:
       context: ./docker/local
     environment:

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,15 +1,4 @@
 FROM druidfi/drupal:8.0-web
 
-# Configure nginx
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY custom.locations /etc/nginx/conf.d/custom.locations
-
-# Override default fpm pool conf to run nginx and php-fpm as same user.
-COPY php-fpm-pool.conf /etc/php8/php-fpm.d/www.conf
-
 # Install chromedriver.
 RUN sudo apk add chromium chromium-chromedriver
-
-# Autostart chromedriver and drush server
-COPY entrypoints/30-chromedriver.sh /entrypoints
-COPY entrypoints/30-drush-server.sh /entrypoints


### PR DESCRIPTION
To test this, run:

- `docker compose build`
- `make stop && make up`

and make sure you can still access the site normally.