### PR TITLE
UHF-2529: menu external link translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "drupal/menu_link_attributes": "^1.2",
         "drupal/purge": "~3.2.0",
         "drupal/raven": "^3.2",
+        "drupal/translatable_menu_link_uri": "^2.0",
         "drupal/varnish_purge": "^2.1",
         "drush/drush": "^10.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88a9cf8d4b1aa76234fbf861bf47a697",
+    "content-hash": "c99db53e086fcb8828f55ae7b0c12df6",
     "packages": [
         {
             "name": "City-of-Helsinki/php-hauki-client",
@@ -5909,6 +5909,50 @@
             "homepage": "https://www.drupal.org/project/token_filter",
             "support": {
                 "source": "https://git.drupalcode.org/project/token_filter"
+            }
+        },
+        {
+            "name": "drupal/translatable_menu_link_uri",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/translatable_menu_link_uri.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/translatable_menu_link_uri-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "6960a485565d886cf35ee6dd56310de47e04e430"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1597491393",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "jsobiecki",
+                    "homepage": "https://www.drupal.org/user/112744"
+                }
+            ],
+            "description": "This module enables support for translation of link field in menu_link_content entity.",
+            "homepage": "https://www.drupal.org/project/translatable_menu_link_uri",
+            "support": {
+                "source": "https://git.drupalcode.org/project/translatable_menu_link_uri"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -108,6 +108,7 @@ module:
   token: 0
   token_filter: 0
   toolbar: 0
+  translatable_menu_link_uri: 0
   twig_tweak: 0
   update: 0
   update_helper: 0


### PR DESCRIPTION
Add module which adds possibility to translate menu link with external url

Run` make new` OR `make fresh`
Or faster way:
Run `composer install`
Run `drush deploy` inside container

Edit any menu by adding new menu item. `/admin/structure/menu/manage/main/add`
 - Add link field value
 - Set language for the menu item
Translate the newly created menu item
 - Let the original url be, instead add the link override field value

Go check the menu with both languages. The external link url should be translated.