### PR TITLE
UHF-2912: Show Smartti Chatbot only with Finnish content

### DIFF
--- a/conf/cmi/block.block.smarttichatbot.yml
+++ b/conf/cmi/block.block.smarttichatbot.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - helfi_platform_config
+    - language
   theme:
     - hdbt
 id: smarttichatbot
@@ -17,4 +18,11 @@ settings:
   label: 'Smartti Chatbot'
   provider: helfi_platform_config
   label_display: '0'
-visibility: {  }
+visibility:
+  language:
+    id: language
+    langcodes:
+      fi: fi
+    negate: false
+    context_mapping:
+      language: '@language.current_language_context:language_content'


### PR DESCRIPTION
**How to test**

* Set up a local _kymp_ environment.
* Checkout this branch and run e.g. `make fresh`.
* View some content (e.g. nodes and custom entities) and check that the Smartti Chatbot at the bottom right is only visible when viewing Finnish content.