### PR TITLE
UHF-2802: Copy commit message to custom and contrib module/theme folders, add Jira ID only if commit message doesn't contain it already

### DIFF
--- a/tools/commit-msg
+++ b/tools/commit-msg
@@ -5,9 +5,11 @@
 # PROJECT-1234-test-test
 # PROJECT-1234_test_test
 id=$(echo `git rev-parse --abbrev-ref HEAD` | sed -nE 's|([a-z]+/)?([A-Z]+-[0-9]+)(-.+)?(_.+)?|\2|p')
+COMMIT_MESSAGE=$(cat $1)
 
-# only prepare commit message if pattern matched and jiraId was found
-if [[ ! -z $id ]]; then
+# Only prepare commit message if pattern matched and Jira ID was found and
+# message doesn't contain Jira ID already.
+if [[ ! -z $id ]] && [[ $COMMIT_MESSAGE != $id* ]]; then
   # $1 is the name of the file containing the commit message
   # Prepend "ABCD-123: "
   sed -i.bak -E "1s/^/${id}: /" $1

--- a/tools/make/project/git.mk
+++ b/tools/make/project/git.mk
@@ -1,3 +1,3 @@
 PHONY += copy-commit-message-script
 copy-commit-message-script:
-	@$(foreach name,$(shell find public/modules/custom public/themes/custom -type d -name ".git" -exec dirname {} \; 2> /dev/null ) .,cp tools/commit-msg $(name)/.git/hooks;)
+	@$(foreach name,$(shell find public/modules/*/* public/themes/*/* -type d -name ".git" -exec dirname {} \; 2> /dev/null ) .,cp tools/commit-msg $(name)/.git/hooks;)


### PR DESCRIPTION
To test this:

- Run `make copy-commit-message-script`
- Add commit with message containing `UHF-{$id}`, like `git commit -m 'UHF-123: Testing' --allow-empty`
- Add commit with message without Jira ID, like `git commit -m 'Testing 2' --allow-empty`

Make sure commit message is only added once.