### PR TITLE
UHF-2478: changed Genesys backend URLs & removed authentication link

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4129,16 +4129,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.0.27",
+            "version": "2.0.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "7306c70deb9bc97817d6e877104943ef8457ef61"
+                "reference": "47fee7b499453eb92bed8095003ee0f0b5c4903e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/7306c70deb9bc97817d6e877104943ef8457ef61",
-                "reference": "7306c70deb9bc97817d6e877104943ef8457ef61",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/47fee7b499453eb92bed8095003ee0f0b5c4903e",
+                "reference": "47fee7b499453eb92bed8095003ee0f0b5c4903e",
                 "shasum": ""
             },
             "require": {
@@ -4221,7 +4221,7 @@
                 "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/latest",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2021-10-28T06:59:45+00:00"
+            "time": "2021-11-01T11:45:26+00:00"
         },
         {
             "name": "drupal/helfi_proxy",


### PR DESCRIPTION
See the actual changes in https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/203.