### PR TITLE
UHF-3541: Add changes to breadcrumb settings, site name and translations

### DIFF
--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -12,7 +12,7 @@ term_hierarchy: false
 absolute_paths: false
 hide_single_home_item: true
 title_from_page_when_available: true
-capitalizator_mode: ucwords
+capitalizator_mode: none
 capitalizator_ignored_words: {  }
 capitalizator_forced_words: {  }
 capitalizator_forced_words_first_letter: false

--- a/conf/cmi/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/helfi_base_config.breadcrumb.yml
@@ -3,6 +3,3 @@ breadcrumb_base_links:
   -
     text: Frontpage
     url: 'https://www.hel.fi/helsinki/en'
-  -
-    text: 'Maps and transport'
-    url: 'https://www.hel.fi/helsinki/en/maps-and-transport/'

--- a/conf/cmi/language/fi/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/language/fi/helfi_base_config.breadcrumb.yml
@@ -2,6 +2,3 @@ breadcrumb_base_links:
   -
     text: Etusivu
     url: 'https://www.hel.fi/helsinki/fi'
-  -
-    text: 'Liikenne ja kartat'
-    url: 'https://www.hel.fi/helsinki/fi/kartat-ja-liikenne/'

--- a/conf/cmi/language/fi/system.site.yml
+++ b/conf/cmi/language/fi/system.site.yml
@@ -1,1 +1,1 @@
-name: Pysäköinti
+name: 'Kaupunkiympäristö ja liikenne'

--- a/conf/cmi/language/ru/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/language/ru/helfi_base_config.breadcrumb.yml
@@ -2,6 +2,3 @@ breadcrumb_base_links:
   -
     text: Frontpage
     url: 'https://www.hel.fi/helsinki/en'
-  -
-    text: 'Maps and transport'
-    url: 'https://www.hel.fi/helsinki/ru/maps/'

--- a/conf/cmi/language/sv/helfi_base_config.breadcrumb.yml
+++ b/conf/cmi/language/sv/helfi_base_config.breadcrumb.yml
@@ -2,6 +2,3 @@ breadcrumb_base_links:
   -
     text: Framsida
     url: 'https://www.hel.fi/helsinki/sv'
-  -
-    text: 'Kartor och trafik'
-    url: 'https://www.hel.fi/helsinki/sv/kartor-och-trafik'

--- a/conf/cmi/language/sv/system.site.yml
+++ b/conf/cmi/language/sv/system.site.yml
@@ -1,1 +1,1 @@
-name: Parkering
+name: 'Stadsmiljö ock trafik'

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -1,11 +1,11 @@
 uuid: 9fdf0ec1-7464-479e-b010-84472b140052
-name: Parking
+name: 'Urban environment and traffic'
 mail: drupal@hel.fi
 slogan: ''
 page:
   403: ''
   404: ''
-  front: /node/1
+  front: /front
 admin_compact_mode: false
 weight_select_max: 100
 langcode: en


### PR DESCRIPTION
How to test:

1. `git checkout UHF-3541_front_page_changes`
2. `make drush-cim && make drush-cr`
3. Make sure that the site name is now: Kaupunkiympäristö ja liikenne/Stadsmiljö och trafik/Urban environment and trafic
4. Make sure that the front page is set as /front (we will do redirects manually to the desired landing page)
5. Make sure that the breadcrumb looks correct: 
Etusivu (old hel.fi front page) > Kaupunkiympäristö ja liikenne (/front) > [PAGE]
Framsida (old hel.fi front page) > Stadsmiljö och trafik (/front) > [PAGE]
Frontpage (old hel.fi front page) > Urban environment and trafic (/front) > [PAGE]