### PR TITLE
UHF-3541: Fix typo on breadcrumb Swedish

### DIFF
--- a/conf/cmi/language/sv/helfi_proxy.settings.yml
+++ b/conf/cmi/language/sv/helfi_proxy.settings.yml
@@ -1,1 +1,1 @@
-front_page_title: 'Stadsmiljo och Trafik'
+front_page_title: 'Stadsmiljö och trafik'


### PR DESCRIPTION
1. `make drush-cim && make drush-cr`
2. Check that the breadcrumb on Swedish version doesn't have typo anymore.