### PR TITLE
UHF-X: Add breadcrumb fix for KYMP

### DIFF
--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -3,9 +3,9 @@ include_invalid_paths: false
 excluded_paths: ''
 replaced_titles: ''
 custom_paths: ''
-include_home_segment: false
+include_home_segment: true
 alternative_title_field: ''
-home_segment_title: Home
+home_segment_title: 'Urban environment and traffic'
 home_segment_keep: false
 include_title_segment: true
 title_from_page_when_available: true

--- a/conf/cmi/language/fi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/fi/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Etusivu
+home_segment_title: 'Kaupunkiympäristö ja liikenne'

--- a/conf/cmi/language/sv/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/sv/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Hem
+home_segment_title: 'Stadsmiljö ock trafik'


### PR DESCRIPTION
How to test:

1. Checkout this branch
2. `make drush-cim && make drush-cr`
3. Go to check the site and make sure that you have "Kaupunkiympäristö ja liikenne / Urban environment and traffic / Stadsmiljö ock trafik" on the breadcrumb like it should have.