### PR TITLE
UHF-X: news list paragraph field weights

### DIFF
--- a/conf/cmi/core.entity_form_display.paragraph.news_list.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.news_list.default.yml
@@ -22,7 +22,7 @@ mode: default
 content:
   field_helfi_news_groups:
     type: select2_entity_reference
-    weight: 3
+    weight: 4
     region: content
     settings:
       width: 100%
@@ -42,7 +42,7 @@ content:
     third_party_settings: {  }
   field_helfi_news_tags:
     type: select2_entity_reference
-    weight: 4
+    weight: 3
     region: content
     settings:
       width: 100%

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -8,3 +8,5 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'sv' => 'test-stadsmiljo-och-trafik',
   'ru' => 'test-urban-environment-and-traffic',
 ];
+
+$config['helfi_news_feed.settings']['source_environment'] = 'test';


### PR DESCRIPTION
- changes the weight of two fields in the News list paragraph
- set the config variable for fetching news items from the correct environment on test

See also the Platform Config PR: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/348