### PR TITLE
UHF-5684: disable hotjar module

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -56,7 +56,6 @@ module:
   helfi_content: 0
   helfi_events: 0
   helfi_gdpr_compliance: 0
-  helfi_hotjar: 0
   helfi_kymp_content: 0
   helfi_kymp_migrations: 0
   helfi_kymp_plans: 0


### PR DESCRIPTION
Disables the Helfi Hotjar module as it was done in PR https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/427 and overridden in https://github.com/City-of-Helsinki/drupal-helfi-kymp/commit/0b142f163572613414f4bf2683817fce7d4ee3b6#diff-ef70b7e49611572a4a4fc13ae4f6092d0a881b7b1fa6d08b59aad9a7069bab08