### PR TITLE
UHF-6300: Remove ctools site specific configs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2744,29 +2744,30 @@
         },
         {
             "name": "drupal/default_content",
-            "version": "2.0.0-alpha1",
+            "version": "2.0.0-alpha2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/default_content.git",
-                "reference": "2.0.0-alpha1"
+                "reference": "2.0.0-alpha2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/default_content-2.0.0-alpha1.zip",
-                "reference": "2.0.0-alpha1",
-                "shasum": "0d534ab8e44786a352e24c7cec3dc06bef155f66"
+                "url": "https://ftp.drupal.org/files/projects/default_content-2.0.0-alpha2.zip",
+                "reference": "2.0.0-alpha2",
+                "shasum": "5c365ea21b0be63dc00ec2db50179291d6fb3d89"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9"
+                "drupal/core": "^9.1 || ^10"
             },
             "require-dev": {
+                "drupal/hal": " ^9 || ^1 || ^2",
                 "drupal/paragraphs": "^1"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-alpha1",
-                    "datestamp": "1595072288",
+                    "version": "2.0.0-alpha2",
+                    "datestamp": "1659466706",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -2774,7 +2775,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9"
+                        "drush.services.yml": "^9 || ^10 || ^11"
                     }
                 }
             },
@@ -2784,20 +2785,16 @@
             ],
             "authors": [
                 {
-                    "name": "Berdir",
-                    "homepage": "https://www.drupal.org/user/214652"
-                },
-                {
-                    "name": "Sam152",
-                    "homepage": "https://www.drupal.org/user/1485048"
-                },
-                {
                     "name": "andypost",
                     "homepage": "https://www.drupal.org/user/118908"
                 },
                 {
                     "name": "benjy",
                     "homepage": "https://www.drupal.org/user/1852732"
+                },
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
                 },
                 {
                     "name": "dawehner",
@@ -2810,6 +2807,10 @@
                 {
                     "name": "larowlan",
                     "homepage": "https://www.drupal.org/user/395439"
+                },
+                {
+                    "name": "Sam152",
+                    "homepage": "https://www.drupal.org/user/1485048"
                 }
             ],
             "description": "Imports default content when a module is enabled",
@@ -4092,16 +4093,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "3.0.20",
+            "version": "3.0.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "0909c1784119ee0c41d3b2584b1709e9a2cee223"
+                "reference": "6bb6d24a8de9c242b8d09fe60073fd899a350d52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/0909c1784119ee0c41d3b2584b1709e9a2cee223",
-                "reference": "0909c1784119ee0c41d3b2584b1709e9a2cee223",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/6bb6d24a8de9c242b8d09fe60073fd899a350d52",
+                "reference": "6bb6d24a8de9c242b8d09fe60073fd899a350d52",
                 "shasum": ""
             },
             "require": {
@@ -4116,10 +4117,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/3.0.20",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/3.0.22",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2022-07-20T11:23:45+00:00"
+            "time": "2022-08-12T07:59:25+00:00"
         },
         {
             "name": "drupal/hdbt_admin",
@@ -4387,16 +4388,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.9.16",
+            "version": "2.9.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "810ebc2a2ef68dad8d12d77bbe411193a3c63ddd"
+                "reference": "71679d2837c6cf7ec4b34c5ad0644f85da4867e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/810ebc2a2ef68dad8d12d77bbe411193a3c63ddd",
-                "reference": "810ebc2a2ef68dad8d12d77bbe411193a3c63ddd",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/71679d2837c6cf7ec4b34c5ad0644f85da4867e9",
+                "reference": "71679d2837c6cf7ec4b34c5ad0644f85da4867e9",
                 "shasum": ""
             },
             "require": {
@@ -4409,7 +4410,7 @@
                 "drupal/content_lock": "^2.2",
                 "drupal/core-recommended": ">=9.3",
                 "drupal/crop": "^2.1",
-                "drupal/default_content": "^2.0.0-alpha1",
+                "drupal/default_content": "^2.0.0-alpha2",
                 "drupal/diff": "^1.0",
                 "drupal/easy_breadcrumb": "^2.0",
                 "drupal/editoria11y": "^1.0",
@@ -4457,6 +4458,9 @@
                 "drupal/views_bulk_edit": "^2.6",
                 "drupal/views_bulk_operations": "^4.1"
             },
+            "conflict": {
+                "drupal/ctools": "<3.11 || ^4.0.1"
+            },
             "type": "drupal-module",
             "extra": {
                 "patches": {
@@ -4471,7 +4475,7 @@
                         "[#UHF-4325] Strip whitespaces from twig debug comments": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/f7c0e380e2deb9a1b46bdf779fb27a945b466575/patches/drupal_core_strip_debug_mode_whitespaces_9.3.x.patch"
                     },
                     "drupal/default_content": {
-                        "https://www.drupal.org/project/default_content/issues/2640734#comment-14399122": "https://www.drupal.org/files/issues/2022-02-04/default_content-2640734-allow_manual_import-108.patch"
+                        "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"
                     },
                     "drupal/eu_cookie_compliance": {
                         "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/d1a6866b2138f7d3597df79f395a5c1a9e19ee2e/patches/eu_cookie_compliance_block_8.x-1.19.patch",
@@ -4506,10 +4510,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.9.16",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.9.18",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2022-07-20T10:58:41+00:00"
+            "time": "2022-08-11T11:34:32+00:00"
         },
         {
             "name": "drupal/helfi_proxy",
@@ -5492,20 +5496,20 @@
         },
         {
             "name": "drupal/pathauto",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/pathauto.git",
-                "reference": "8.x-1.10"
+                "reference": "8.x-1.11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.10.zip",
-                "reference": "8.x-1.10",
-                "shasum": "f49d5fbcd7a2c1b4de1da07194fe01d9012237ec"
+                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.11.zip",
+                "reference": "8.x-1.11",
+                "shasum": "a006fe9e6046a9833711a1ae56aa4752e65bcdc8"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9",
+                "drupal/core": "^9.3 || ^10",
                 "drupal/ctools": "*",
                 "drupal/token": "*"
             },
@@ -5515,8 +5519,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.10",
-                    "datestamp": "1650806739",
+                    "version": "8.x-1.11",
+                    "datestamp": "1660129564",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/conf/cmi/block.block.hdbt_page_title.yml
+++ b/conf/cmi/block.block.hdbt_page_title.yml
@@ -2,8 +2,6 @@ uuid: a02865dc-d801-4360-9127-25042c55bac5
 langcode: en
 status: true
 dependencies:
-  module:
-    - ctools
   theme:
     - hdbt
 _core:

--- a/conf/cmi/block.block.heroblock.yml
+++ b/conf/cmi/block.block.heroblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - ctools
     - hdbt_content
   theme:
     - hdbt

--- a/conf/cmi/block.block.main_navigation_level_2.yml
+++ b/conf/cmi/block.block.main_navigation_level_2.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - system.menu.main
   module:
-    - ctools
     - menu_block_current_language
   theme:
     - hdbt

--- a/conf/cmi/block.block.sidebarcontentblock.yml
+++ b/conf/cmi/block.block.sidebarcontentblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - ctools
     - hdbt_content
   theme:
     - hdbt

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -19,7 +19,6 @@ module:
   content_lock: 0
   content_lock_timeout: 0
   crop: 0
-  ctools: 0
   datetime: 0
   datetime_range: 0
   diff: 0


### PR DESCRIPTION
# [UHF-6300](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6300)

After pathauto 8.x-1.11 release, which removed the ctools dependency, ctools is longer needed.

## What was done
* Made sure that pathauto is updated to version 8.x-1.11.
* Removed ctools dependencies from site specific configs, if any.
* Uninstalled ctools using site configs.
* This PR is marked as draft until the related releases for _hdbt_ and _platform config_ are done and this PR is updated to use those releases.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6300-kymp-remove-ctools`
* `make shell` and
  * `composer require drupal/helfi_platform_config:dev-UHF-6300-remove-ctools`
  * `composer require drupal/hdbt:dev-UHF-6300-hdbt-remove-ctools`
* `make fresh`
* Run `make drush-cr`

## How to test
* Check that the ctools module is disabled and the site still seems to work correctly.

* [x] Check that this feature works
* [x] Check that code follows our standards

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
* Theme and module updates:
  * https://github.com/City-of-Helsinki/drupal-hdbt/pull/382
  * https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/352
* Other site specific PRs:
  * 
