### PR TITLE
UHF-6214: Add missing translation for paragraph type

### DIFF
--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.district_and_project_search.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.district_and_project_search.yml
@@ -1,0 +1,1 @@
+label: 'Alue- ja hankehaku'

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.district_and_project_search.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.district_and_project_search.yml
@@ -1,0 +1,1 @@
+label: 'Område- och projektsökning'


### PR DESCRIPTION
Forgot to add translation for district and project search paragraph type.