### PR TITLE
UHF-6142: Added a search parameters field for project list paragraph

### DIFF
--- a/conf/cmi/core.entity_form_display.paragraph.project_listing.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.project_listing.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.project_listing.field_district_taxonomy
     - field.field.paragraph.project_listing.field_project_list_description
     - field.field.paragraph.project_listing.field_project_list_title
+    - field.field.paragraph.project_listing.field_search_link_parameters
     - paragraphs.paragraphs_type.project_listing
   module:
     - select2
@@ -39,6 +40,14 @@ content:
     region: content
     settings:
       size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_search_link_parameters:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 120
       placeholder: ''
     third_party_settings: {  }
 hidden:

--- a/conf/cmi/core.entity_view_display.paragraph.project_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.project_listing.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.project_listing.field_district_taxonomy
     - field.field.paragraph.project_listing.field_project_list_description
     - field.field.paragraph.project_listing.field_project_list_title
+    - field.field.paragraph.project_listing.field_search_link_parameters
     - paragraphs.paragraphs_type.project_listing
   module:
     - text
@@ -36,5 +37,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_search_link_parameters:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
 hidden: {  }

--- a/conf/cmi/field.field.paragraph.project_listing.field_search_link_parameters.yml
+++ b/conf/cmi/field.field.paragraph.project_listing.field_search_link_parameters.yml
@@ -1,0 +1,19 @@
+uuid: 8cc20c8a-76f9-403f-a252-82c1835bf4d7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_search_link_parameters
+    - paragraphs.paragraphs_type.project_listing
+id: paragraph.project_listing.field_search_link_parameters
+field_name: field_search_link_parameters
+entity_type: paragraph
+bundle: project_listing
+label: 'Search link parameters'
+description: 'If you want to link the "Refined search" button to certain set of results copy the parameters from the search url here. For example <code>/?area=%5B"Kalasatama"%5D</code> '
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.paragraph.field_search_link_parameters.yml
+++ b/conf/cmi/field.storage.paragraph.field_search_link_parameters.yml
@@ -1,0 +1,21 @@
+uuid: eb3bd302-9da2-4f44-a0b9-f7201b5d6a44
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_search_link_parameters
+field_name: field_search_link_parameters
+entity_type: paragraph
+type: string
+settings:
+  max_length: 500
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/helfi_kymp_content.project_search.yml
+++ b/conf/cmi/helfi_kymp_content.project_search.yml
@@ -1,1 +1,1 @@
-project_search_path: ''
+project_search_path: /node/39

--- a/conf/cmi/helfi_kymp_content.project_search.yml
+++ b/conf/cmi/helfi_kymp_content.project_search.yml
@@ -1,1 +1,1 @@
-project_search_path: /node/39
+project_search_path: ''

--- a/conf/cmi/language/fi/field.field.paragraph.project_listing.field_search_link_parameters.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.project_listing.field_search_link_parameters.yml
@@ -1,0 +1,2 @@
+label: 'Hakulinkin parametrit'
+description: 'Jos haluat linkittää "Tarkennettu haku" linkin tiettyihin tuloksiin alue- ja hankehaussa niin kopioi hakusivun url-riviltä parametrit tähän kenttään. Esimerkiksi <code>/?area=%5B"Kalasatama"%5D</code>'

--- a/conf/cmi/language/sv/field.field.paragraph.project_listing.field_search_link_parameters.yml
+++ b/conf/cmi/language/sv/field.field.paragraph.project_listing.field_search_link_parameters.yml
@@ -1,0 +1,2 @@
+label: 'Sök länkparametrar'
+description: 'Om du vill länka knappen "Förfinad sökning" till en viss uppsättning resultat, kopiera parametrarna från sökadressen här. Till exempel <code>/?area=%5B"Kalasatama"%5D</code> '

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -77,8 +77,8 @@ function hdbt_subtheme_theme_suggestions_menu_alter(&$suggestions, $variables) {
  */
 function hdbt_subtheme_preprocess_paragraph__project_listing(&$variables) {
   $paragraph = $variables['paragraph'];
-  $selected_district = $paragraph->get('field_district_taxonomy')->target_id;
-  $variables['selected_district'] = $selected_district;
+  $variables['selected_district'] = $paragraph->get('field_district_taxonomy')->target_id;
+  $variables['search_parameters'] = $paragraph->get('field_search_link_parameters')->value;
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--project-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--project-listing.html.twig
@@ -9,7 +9,7 @@
   %}
     {% block component_content %}
       <div class="project-list__list">
-        {{ drupal_view('project_list', 'block_1', selected_district) }}
+        {{ drupal_view('project_list', 'block_1', selected_district, search_parameters) }}
       </div>
     {% endblock component_content %}
 	{% endembed %}

--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--project-list.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--project-list.html.twig
@@ -44,7 +44,6 @@
   {% set search_parameters = '' %}
 {% endif %}
 
-{{ dd() }}
 <div{{attributes.addClass(classes)}}>
   {{ title_prefix }}
   {{ title }}

--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--project-list.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--project-list.html.twig
@@ -38,6 +38,13 @@
     dom_id ? 'js-view-dom-id-' ~ dom_id,
   ]
 %}
+{% if (view.args.1) %}
+  {% set  search_parameters = view.args.1 %}
+{% else %}
+  {% set search_parameters = '' %}
+{% endif %}
+
+{{ dd() }}
 <div{{attributes.addClass(classes)}}>
   {{ title_prefix }}
   {{ title }}
@@ -61,10 +68,10 @@
   <div class="project-list__buttons">
     {{ pager }}
     {% if search_link %}
-      <a href="{{ search_link }}" class="hds-button hds-button--secondary" rel="next">
+      <a href="{{ search_link }}{{ search_parameters }}" class="hds-button hds-button--secondary" rel="next">
         <span class="hds-button__label">{{ 'Refine search'|t({}, {'context': 'Project list, refine search'}) }}</span>
       </a>
-    {% endif %} 
+    {% endif %}
   </div>
 
 


### PR DESCRIPTION
# [UHF-6142](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6142)
<!-- What problem does this solve? -->
Make it possible for content producers to link the project listing paragraph to certain set of results in district and project search page.

## What was done
<!-- Describe what was done -->

* Added a search parameters field for project list paragraph.
* Render the parameters after the base url that we get from /admin/config/services/kymp-content settings.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6142_search_parameters_for_project_list_paragraph_refined_search`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in to your local site and go to edit /admin/config/services/kymp-content settings. Add for example `/node/39` as the Path for project search page.
* [ ] Go to https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/esimerkkialue for example and edit the page. There should now be a new field called Search link parameters where you can add url parameters for the search page url that is provided in /admin/config/services/kymp-content settings.
* [ ] Save the page and view the paragraph and make sure that the "Refine search" button links to url that is combined from the Path for project search page and Search link parameters.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
