### PR TITLE
UHF-6531: Permissions for admin to project taxonomies

### DIFF
--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -18,6 +18,11 @@ dependencies:
     - node.type.project
     - rest.resource.helfi_debug_data
     - taxonomy.vocabulary.keywords
+    - taxonomy.vocabulary.project_district
+    - taxonomy.vocabulary.project_phase
+    - taxonomy.vocabulary.project_sub_district
+    - taxonomy.vocabulary.project_theme
+    - taxonomy.vocabulary.project_type
   module:
     - block
     - config_translation
@@ -105,6 +110,11 @@ permissions:
   - 'create remote_video media'
   - 'create soundcloud media'
   - 'create terms in keywords'
+  - 'create terms in project_district'
+  - 'create terms in project_phase'
+  - 'create terms in project_sub_district'
+  - 'create terms in project_theme'
+  - 'create terms in project_type'
   - 'create url aliases'
   - 'delete all revisions'
   - 'delete announcement revisions'
@@ -164,6 +174,11 @@ permissions:
   - 'edit paragraph library item'
   - 'edit remote entities'
   - 'edit terms in keywords'
+  - 'edit terms in project_district'
+  - 'edit terms in project_phase'
+  - 'edit terms in project_sub_district'
+  - 'edit terms in project_theme'
+  - 'edit terms in project_type'
   - 'restful get helfi_debug_data'
   - 'revert all revisions'
   - 'revert all tpr_service revisions'


### PR DESCRIPTION
# [UHF-6531](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6531)
Permission for admin to add and edit project taxonomies

## What was done
* Adder permissions for the admin role to add and edit project taxonomies

## How to install
1. set up KYMP instance
2. checkout this branch: `git checkout UHF-6531_admin_taxonomy_permissions`
3. import config: `make drush-cim`
4. clear cache: `make drush-cr`

## How to test
1. login as an admin user
2. make sure you can add and edit terms in following taxonomies:
  i. Project district
  ii. Project phase
  iii. Project sub district
  iv. Project theme
  v. Project type

* [x] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
* N/A
