### PR TITLE
UHF-6522: Fixed sorting on district listing

### DIFF
--- a/conf/cmi/views.view.district_listing.yml
+++ b/conf/cmi/views.view.district_listing.yml
@@ -113,22 +113,6 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          order: DESC
-          expose:
-            label: ''
-            field_identifier: ''
-          exposed: false
-          granularity: second
         title:
           id: title
           table: node_field_data
@@ -139,7 +123,7 @@ display:
           entity_type: node
           entity_field: title
           plugin_id: standard
-          order: DESC
+          order: ASC
           expose:
             label: ''
             field_identifier: ''


### PR DESCRIPTION
# [UHF-6522](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6522)
<!-- What problem does this solve? -->
Fix sorting issue on district listing.

## What was done
<!-- Describe what was done -->

* Removed sort by created date and switched to asc sort on the name.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6522_district_listing_sort_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to landing page that has district listing and check that the items are in alphabetical order.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review