### PR TITLE
UHF-6506: Added few paragraphs available for the district and project pages

### DIFF
--- a/conf/cmi/field.field.node.district.field_content.yml
+++ b/conf/cmi/field.field.node.district.field_content.yml
@@ -6,14 +6,24 @@ dependencies:
     - field.storage.node.field_content
     - node.type.district
     - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
+    - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.contact_card_listing
+    - paragraphs.paragraphs_type.content_cards
+    - paragraphs.paragraphs_type.content_liftup
     - paragraphs.paragraphs_type.event_list
+    - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.list_of_links
+    - paragraphs.paragraphs_type.list_of_plans
     - paragraphs.paragraphs_type.map
     - paragraphs.paragraphs_type.news_list
+    - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.project_listing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.district.field_content
@@ -30,105 +40,133 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      accordion: accordion
-      contact_card_listing: contact_card_listing
-      event_list: event_list
-      image: image
-      map: map
-      news_list: news_list
-      remote_video: remote_video
-      project_listing: project_listing
       text: text
+      columns: columns
+      accordion: accordion
+      image: image
+      content_liftup: content_liftup
+      list_of_links: list_of_links
+      content_cards: content_cards
+      banner: banner
+      from_library: from_library
+      chart: chart
+      remote_video: remote_video
+      unit_search: unit_search
+      event_list: event_list
+      news_list: news_list
+      contact_card_listing: contact_card_listing
+      map: map
+      list_of_plans: list_of_plans
+      phasing: phasing
+      project_listing: project_listing
     negate: 0
     target_bundles_drag_drop:
       accordion:
-        weight: 30
+        weight: -71
         enabled: true
       accordion_item:
-        weight: 31
+        weight: -65
         enabled: false
       banner:
-        weight: 32
-        enabled: false
+        weight: -61
+        enabled: true
       chart:
-        weight: 33
-        enabled: false
+        weight: -58
+        enabled: true
       columns:
-        weight: 34
-        enabled: false
+        weight: -72
+        enabled: true
       contact_card:
-        weight: 35
+        weight: -55
         enabled: false
       contact_card_listing:
-        weight: 36
+        weight: -51
         enabled: true
       content_cards:
-        weight: 37
-        enabled: false
+        weight: -66
+        enabled: true
       content_liftup:
-        weight: 38
+        weight: -68
+        enabled: true
+      district_and_project_search:
+        weight: -48
+        enabled: false
+      district_listing:
+        weight: -45
         enabled: false
       event_list:
-        weight: 39
+        weight: -54
         enabled: true
       from_library:
-        weight: 40
-        enabled: false
+        weight: -59
+        enabled: true
       gallery:
-        weight: 41
+        weight: -69
         enabled: false
       gallery_slide:
-        weight: 42
+        weight: -64
         enabled: false
       hero:
-        weight: 43
+        weight: -63
         enabled: false
       image:
-        weight: 44
+        weight: -70
         enabled: true
       liftup_with_image:
-        weight: 45
+        weight: -60
         enabled: false
       list_of_links:
-        weight: 46
-        enabled: false
+        weight: -67
+        enabled: true
       list_of_links_item:
-        weight: 47
+        weight: -62
         enabled: false
       list_of_plans:
-        weight: 48
-        enabled: false
+        weight: -49
+        enabled: true
       map:
-        weight: 49
+        weight: -50
         enabled: true
       news_list:
-        weight: 50
+        weight: -53
         enabled: true
       phasing:
-        weight: 51
-        enabled: false
+        weight: -43
+        enabled: true
       phasing_item:
-        weight: 52
+        weight: -52
+        enabled: false
+      popular_service_item:
+        weight: -42
+        enabled: false
+      popular_services:
+        weight: -41
         enabled: false
       project_listing:
-        weight: 54
+        weight: -40
         enabled: true
       remote_video:
-        weight: 53
+        weight: -57
         enabled: true
       service_list:
-        weight: 54
+        weight: -47
         enabled: false
       sidebar_text:
-        weight: 55
+        weight: -44
         enabled: false
       social_media_link:
-        weight: 56
+        weight: -46
+        enabled: false
+      target_group_link_item:
+        weight: -39
+        enabled: false
+      target_group_links:
+        weight: -38
         enabled: false
       text:
-        weight: 57
+        weight: -73
         enabled: true
       unit_search:
-        weight: 58
-        enabled: false
+        weight: -56
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.district.field_content.yml
+++ b/conf/cmi/field.field.node.district.field_content.yml
@@ -7,23 +7,17 @@ dependencies:
     - node.type.district
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.banner
-    - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.contact_card_listing
-    - paragraphs.paragraphs_type.content_cards
-    - paragraphs.paragraphs_type.content_liftup
     - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
-    - paragraphs.paragraphs_type.list_of_plans
     - paragraphs.paragraphs_type.map
     - paragraphs.paragraphs_type.news_list
-    - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.project_listing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
-    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.district.field_content
@@ -44,20 +38,14 @@ settings:
       columns: columns
       accordion: accordion
       image: image
-      content_liftup: content_liftup
       list_of_links: list_of_links
-      content_cards: content_cards
       banner: banner
       from_library: from_library
-      chart: chart
       remote_video: remote_video
-      unit_search: unit_search
       event_list: event_list
       news_list: news_list
       contact_card_listing: contact_card_listing
       map: map
-      list_of_plans: list_of_plans
-      phasing: phasing
       project_listing: project_listing
     negate: 0
     target_bundles_drag_drop:
@@ -72,7 +60,7 @@ settings:
         enabled: true
       chart:
         weight: -58
-        enabled: true
+        enabled: false
       columns:
         weight: -72
         enabled: true
@@ -84,10 +72,10 @@ settings:
         enabled: true
       content_cards:
         weight: -66
-        enabled: true
+        enabled: false
       content_liftup:
         weight: -68
-        enabled: true
+        enabled: false
       district_and_project_search:
         weight: -48
         enabled: false
@@ -123,7 +111,7 @@ settings:
         enabled: false
       list_of_plans:
         weight: -49
-        enabled: true
+        enabled: false
       map:
         weight: -50
         enabled: true
@@ -132,7 +120,7 @@ settings:
         enabled: true
       phasing:
         weight: -43
-        enabled: true
+        enabled: false
       phasing_item:
         weight: -52
         enabled: false
@@ -168,5 +156,5 @@ settings:
         enabled: true
       unit_search:
         weight: -56
-        enabled: true
+        enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.district.field_lower_content.yml
+++ b/conf/cmi/field.field.node.district.field_lower_content.yml
@@ -5,24 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_lower_content
     - node.type.district
-    - paragraphs.paragraphs_type.accordion
-    - paragraphs.paragraphs_type.banner
-    - paragraphs.paragraphs_type.chart
-    - paragraphs.paragraphs_type.columns
-    - paragraphs.paragraphs_type.contact_card_listing
-    - paragraphs.paragraphs_type.content_cards
-    - paragraphs.paragraphs_type.content_liftup
-    - paragraphs.paragraphs_type.event_list
-    - paragraphs.paragraphs_type.from_library
-    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
-    - paragraphs.paragraphs_type.list_of_plans
-    - paragraphs.paragraphs_type.map
-    - paragraphs.paragraphs_type.news_list
-    - paragraphs.paragraphs_type.phasing
-    - paragraphs.paragraphs_type.remote_video
-    - paragraphs.paragraphs_type.text
-    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.district.field_lower_content
@@ -39,53 +22,36 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      text: text
-      columns: columns
-      accordion: accordion
-      image: image
       list_of_links: list_of_links
-      content_cards: content_cards
-      content_liftup: content_liftup
-      banner: banner
-      unit_search: unit_search
-      from_library: from_library
-      chart: chart
-      event_list: event_list
-      news_list: news_list
-      contact_card_listing: contact_card_listing
-      map: map
-      remote_video: remote_video
-      list_of_plans: list_of_plans
-      phasing: phasing
     negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: -71
-        enabled: true
+        enabled: false
       accordion_item:
         weight: -66
         enabled: false
       banner:
         weight: -64
-        enabled: true
+        enabled: false
       chart:
         weight: -57
-        enabled: true
+        enabled: false
       columns:
         weight: -72
-        enabled: true
+        enabled: false
       contact_card:
         weight: -56
         enabled: false
       contact_card_listing:
         weight: -52
-        enabled: true
+        enabled: false
       content_cards:
         weight: -67
-        enabled: true
+        enabled: false
       content_liftup:
         weight: -65
-        enabled: true
+        enabled: false
       district_and_project_search:
         weight: -48
         enabled: false
@@ -94,10 +60,10 @@ settings:
         enabled: false
       event_list:
         weight: -55
-        enabled: true
+        enabled: false
       from_library:
         weight: -58
-        enabled: true
+        enabled: false
       gallery:
         weight: -69
         enabled: false
@@ -109,7 +75,7 @@ settings:
         enabled: false
       image:
         weight: -70
-        enabled: true
+        enabled: false
       liftup_with_image:
         weight: -61
         enabled: false
@@ -121,16 +87,16 @@ settings:
         enabled: false
       list_of_plans:
         weight: -49
-        enabled: true
+        enabled: false
       map:
         weight: -51
-        enabled: true
+        enabled: false
       news_list:
         weight: -54
-        enabled: true
+        enabled: false
       phasing:
         weight: -43
-        enabled: true
+        enabled: false
       phasing_item:
         weight: -53
         enabled: false
@@ -145,7 +111,7 @@ settings:
         enabled: false
       remote_video:
         weight: -50
-        enabled: true
+        enabled: false
       service_list:
         weight: -47
         enabled: false
@@ -163,8 +129,8 @@ settings:
         enabled: false
       text:
         weight: -73
-        enabled: true
+        enabled: false
       unit_search:
         weight: -59
-        enabled: true
+        enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.district.field_lower_content.yml
+++ b/conf/cmi/field.field.node.district.field_lower_content.yml
@@ -5,7 +5,24 @@ dependencies:
   config:
     - field.storage.node.field_lower_content
     - node.type.district
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
+    - paragraphs.paragraphs_type.columns
+    - paragraphs.paragraphs_type.contact_card_listing
+    - paragraphs.paragraphs_type.content_cards
+    - paragraphs.paragraphs_type.content_liftup
+    - paragraphs.paragraphs_type.event_list
+    - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
+    - paragraphs.paragraphs_type.list_of_plans
+    - paragraphs.paragraphs_type.map
+    - paragraphs.paragraphs_type.news_list
+    - paragraphs.paragraphs_type.phasing
+    - paragraphs.paragraphs_type.remote_video
+    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.district.field_lower_content
@@ -22,94 +39,132 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
+      text: text
+      columns: columns
+      accordion: accordion
+      image: image
       list_of_links: list_of_links
+      content_cards: content_cards
+      content_liftup: content_liftup
+      banner: banner
+      unit_search: unit_search
+      from_library: from_library
+      chart: chart
+      event_list: event_list
+      news_list: news_list
+      contact_card_listing: contact_card_listing
+      map: map
+      remote_video: remote_video
+      list_of_plans: list_of_plans
+      phasing: phasing
     negate: 0
     target_bundles_drag_drop:
       accordion:
-        weight: 30
-        enabled: false
+        weight: -71
+        enabled: true
       accordion_item:
-        weight: 31
+        weight: -66
         enabled: false
       banner:
-        weight: 32
-        enabled: false
+        weight: -64
+        enabled: true
       chart:
-        weight: 33
-        enabled: false
+        weight: -57
+        enabled: true
       columns:
-        weight: 34
-        enabled: false
+        weight: -72
+        enabled: true
       contact_card:
-        weight: 35
+        weight: -56
         enabled: false
       contact_card_listing:
-        weight: 36
-        enabled: false
+        weight: -52
+        enabled: true
       content_cards:
-        weight: 37
-        enabled: false
+        weight: -67
+        enabled: true
       content_liftup:
-        weight: 38
+        weight: -65
+        enabled: true
+      district_and_project_search:
+        weight: -48
+        enabled: false
+      district_listing:
+        weight: -45
         enabled: false
       event_list:
-        weight: 39
-        enabled: false
+        weight: -55
+        enabled: true
       from_library:
-        weight: 40
-        enabled: false
+        weight: -58
+        enabled: true
       gallery:
-        weight: 41
+        weight: -69
         enabled: false
       gallery_slide:
-        weight: 42
+        weight: -63
         enabled: false
       hero:
-        weight: 43
+        weight: -62
         enabled: false
       image:
-        weight: 44
-        enabled: false
+        weight: -70
+        enabled: true
       liftup_with_image:
-        weight: 45
+        weight: -61
         enabled: false
       list_of_links:
-        weight: 46
+        weight: -68
         enabled: true
       list_of_links_item:
-        weight: 47
+        weight: -60
         enabled: false
       list_of_plans:
-        weight: 48
-        enabled: false
+        weight: -49
+        enabled: true
       map:
-        weight: 49
-        enabled: false
+        weight: -51
+        enabled: true
       news_list:
-        weight: 50
-        enabled: false
+        weight: -54
+        enabled: true
       phasing:
-        weight: 51
-        enabled: false
+        weight: -43
+        enabled: true
       phasing_item:
-        weight: 52
+        weight: -53
+        enabled: false
+      popular_service_item:
+        weight: -42
+        enabled: false
+      popular_services:
+        weight: -41
+        enabled: false
+      project_listing:
+        weight: -40
         enabled: false
       remote_video:
-        weight: 53
-        enabled: false
+        weight: -50
+        enabled: true
       service_list:
-        weight: 54
+        weight: -47
         enabled: false
       sidebar_text:
-        weight: 55
+        weight: -44
         enabled: false
       social_media_link:
-        weight: 56
+        weight: -46
+        enabled: false
+      target_group_link_item:
+        weight: -39
+        enabled: false
+      target_group_links:
+        weight: -38
         enabled: false
       text:
-        weight: 57
-        enabled: false
+        weight: -73
+        enabled: true
       unit_search:
-        weight: 58
-        enabled: false
+        weight: -59
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.project.field_content.yml
+++ b/conf/cmi/field.field.node.project.field_content.yml
@@ -7,22 +7,16 @@ dependencies:
     - node.type.project
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.banner
-    - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.contact_card_listing
-    - paragraphs.paragraphs_type.content_cards
-    - paragraphs.paragraphs_type.content_liftup
     - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
-    - paragraphs.paragraphs_type.list_of_plans
     - paragraphs.paragraphs_type.map
-    - paragraphs.paragraphs_type.news_list
     - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
-    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.project.field_content
@@ -43,19 +37,13 @@ settings:
       columns: columns
       accordion: accordion
       image: image
-      content_liftup: content_liftup
       list_of_links: list_of_links
-      content_cards: content_cards
       banner: banner
       from_library: from_library
-      chart: chart
       remote_video: remote_video
-      unit_search: unit_search
       event_list: event_list
-      news_list: news_list
       contact_card_listing: contact_card_listing
       map: map
-      list_of_plans: list_of_plans
       phasing: phasing
     negate: 0
     target_bundles_drag_drop:
@@ -70,7 +58,7 @@ settings:
         enabled: true
       chart:
         weight: -58
-        enabled: true
+        enabled: false
       columns:
         weight: -72
         enabled: true
@@ -82,10 +70,10 @@ settings:
         enabled: true
       content_cards:
         weight: -66
-        enabled: true
+        enabled: false
       content_liftup:
         weight: -68
-        enabled: true
+        enabled: false
       district_and_project_search:
         weight: -48
         enabled: false
@@ -121,13 +109,13 @@ settings:
         enabled: false
       list_of_plans:
         weight: -49
-        enabled: true
+        enabled: false
       map:
         weight: -50
         enabled: true
       news_list:
         weight: -53
-        enabled: true
+        enabled: false
       phasing:
         weight: -43
         enabled: true
@@ -166,5 +154,5 @@ settings:
         enabled: true
       unit_search:
         weight: -56
-        enabled: true
+        enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.project.field_content.yml
+++ b/conf/cmi/field.field.node.project.field_content.yml
@@ -6,13 +6,23 @@ dependencies:
     - field.storage.node.field_content
     - node.type.project
     - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
+    - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.contact_card_listing
+    - paragraphs.paragraphs_type.content_cards
+    - paragraphs.paragraphs_type.content_liftup
     - paragraphs.paragraphs_type.event_list
+    - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
+    - paragraphs.paragraphs_type.list_of_plans
     - paragraphs.paragraphs_type.map
+    - paragraphs.paragraphs_type.news_list
     - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.project.field_content
@@ -29,101 +39,132 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      accordion: accordion
-      contact_card_listing: contact_card_listing
-      event_list: event_list
-      list_of_links: list_of_links
-      map: map
-      phasing: phasing
-      remote_video: remote_video
       text: text
+      columns: columns
+      accordion: accordion
+      image: image
+      content_liftup: content_liftup
+      list_of_links: list_of_links
+      content_cards: content_cards
+      banner: banner
+      from_library: from_library
+      chart: chart
+      remote_video: remote_video
+      unit_search: unit_search
+      event_list: event_list
+      news_list: news_list
+      contact_card_listing: contact_card_listing
+      map: map
+      list_of_plans: list_of_plans
+      phasing: phasing
     negate: 0
     target_bundles_drag_drop:
       accordion:
-        weight: 30
+        weight: -71
         enabled: true
       accordion_item:
-        weight: 31
+        weight: -65
         enabled: false
       banner:
-        weight: 32
-        enabled: false
+        weight: -61
+        enabled: true
       chart:
-        weight: 33
-        enabled: false
+        weight: -58
+        enabled: true
       columns:
-        weight: 34
-        enabled: false
+        weight: -72
+        enabled: true
       contact_card:
-        weight: 35
+        weight: -55
         enabled: false
       contact_card_listing:
-        weight: 36
+        weight: -51
         enabled: true
       content_cards:
-        weight: 37
-        enabled: false
+        weight: -66
+        enabled: true
       content_liftup:
-        weight: 38
+        weight: -68
+        enabled: true
+      district_and_project_search:
+        weight: -48
+        enabled: false
+      district_listing:
+        weight: -45
         enabled: false
       event_list:
-        weight: 39
+        weight: -54
         enabled: true
       from_library:
-        weight: 40
-        enabled: false
+        weight: -59
+        enabled: true
       gallery:
-        weight: 41
+        weight: -69
         enabled: false
       gallery_slide:
-        weight: 42
+        weight: -64
         enabled: false
       hero:
-        weight: 43
+        weight: -63
         enabled: false
       image:
-        weight: 44
-        enabled: false
+        weight: -70
+        enabled: true
       liftup_with_image:
-        weight: 45
+        weight: -60
         enabled: false
       list_of_links:
-        weight: 46
+        weight: -67
         enabled: true
       list_of_links_item:
-        weight: 47
+        weight: -62
         enabled: false
       list_of_plans:
-        weight: 48
-        enabled: false
+        weight: -49
+        enabled: true
       map:
-        weight: 49
+        weight: -50
         enabled: true
       news_list:
-        weight: 50
-        enabled: false
+        weight: -53
+        enabled: true
       phasing:
-        weight: 51
+        weight: -43
         enabled: true
       phasing_item:
-        weight: 52
+        weight: -52
+        enabled: false
+      popular_service_item:
+        weight: -42
+        enabled: false
+      popular_services:
+        weight: -41
+        enabled: false
+      project_listing:
+        weight: -40
         enabled: false
       remote_video:
-        weight: 53
+        weight: -57
         enabled: true
       service_list:
-        weight: 54
+        weight: -47
         enabled: false
       sidebar_text:
-        weight: 55
+        weight: -44
         enabled: false
       social_media_link:
-        weight: 56
+        weight: -46
+        enabled: false
+      target_group_link_item:
+        weight: -39
+        enabled: false
+      target_group_links:
+        weight: -38
         enabled: false
       text:
-        weight: 57
+        weight: -73
         enabled: true
       unit_search:
-        weight: 58
-        enabled: false
+        weight: -56
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.project.field_lower_content.yml
+++ b/conf/cmi/field.field.node.project.field_lower_content.yml
@@ -5,24 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_lower_content
     - node.type.project
-    - paragraphs.paragraphs_type.accordion
-    - paragraphs.paragraphs_type.banner
-    - paragraphs.paragraphs_type.chart
-    - paragraphs.paragraphs_type.columns
-    - paragraphs.paragraphs_type.contact_card_listing
-    - paragraphs.paragraphs_type.content_cards
-    - paragraphs.paragraphs_type.content_liftup
-    - paragraphs.paragraphs_type.event_list
-    - paragraphs.paragraphs_type.from_library
-    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
-    - paragraphs.paragraphs_type.list_of_plans
-    - paragraphs.paragraphs_type.map
-    - paragraphs.paragraphs_type.news_list
-    - paragraphs.paragraphs_type.phasing
-    - paragraphs.paragraphs_type.remote_video
-    - paragraphs.paragraphs_type.text
-    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.project.field_lower_content
@@ -39,53 +22,36 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      text: text
-      columns: columns
-      accordion: accordion
-      image: image
       list_of_links: list_of_links
-      content_cards: content_cards
-      content_liftup: content_liftup
-      banner: banner
-      unit_search: unit_search
-      from_library: from_library
-      chart: chart
-      event_list: event_list
-      news_list: news_list
-      contact_card_listing: contact_card_listing
-      map: map
-      remote_video: remote_video
-      list_of_plans: list_of_plans
-      phasing: phasing
     negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: -71
-        enabled: true
+        enabled: false
       accordion_item:
         weight: -66
         enabled: false
       banner:
         weight: -64
-        enabled: true
+        enabled: false
       chart:
         weight: -57
-        enabled: true
+        enabled: false
       columns:
         weight: -72
-        enabled: true
+        enabled: false
       contact_card:
         weight: -56
         enabled: false
       contact_card_listing:
         weight: -52
-        enabled: true
+        enabled: false
       content_cards:
         weight: -67
-        enabled: true
+        enabled: false
       content_liftup:
         weight: -65
-        enabled: true
+        enabled: false
       district_and_project_search:
         weight: -48
         enabled: false
@@ -94,10 +60,10 @@ settings:
         enabled: false
       event_list:
         weight: -55
-        enabled: true
+        enabled: false
       from_library:
         weight: -58
-        enabled: true
+        enabled: false
       gallery:
         weight: -69
         enabled: false
@@ -109,7 +75,7 @@ settings:
         enabled: false
       image:
         weight: -70
-        enabled: true
+        enabled: false
       liftup_with_image:
         weight: -61
         enabled: false
@@ -121,16 +87,16 @@ settings:
         enabled: false
       list_of_plans:
         weight: -49
-        enabled: true
+        enabled: false
       map:
         weight: -51
-        enabled: true
+        enabled: false
       news_list:
         weight: -54
-        enabled: true
+        enabled: false
       phasing:
         weight: -43
-        enabled: true
+        enabled: false
       phasing_item:
         weight: -53
         enabled: false
@@ -145,7 +111,7 @@ settings:
         enabled: false
       remote_video:
         weight: -50
-        enabled: true
+        enabled: false
       service_list:
         weight: -47
         enabled: false
@@ -163,8 +129,8 @@ settings:
         enabled: false
       text:
         weight: -73
-        enabled: true
+        enabled: false
       unit_search:
         weight: -59
-        enabled: true
+        enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.project.field_lower_content.yml
+++ b/conf/cmi/field.field.node.project.field_lower_content.yml
@@ -5,7 +5,24 @@ dependencies:
   config:
     - field.storage.node.field_lower_content
     - node.type.project
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
+    - paragraphs.paragraphs_type.columns
+    - paragraphs.paragraphs_type.contact_card_listing
+    - paragraphs.paragraphs_type.content_cards
+    - paragraphs.paragraphs_type.content_liftup
+    - paragraphs.paragraphs_type.event_list
+    - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
+    - paragraphs.paragraphs_type.list_of_plans
+    - paragraphs.paragraphs_type.map
+    - paragraphs.paragraphs_type.news_list
+    - paragraphs.paragraphs_type.phasing
+    - paragraphs.paragraphs_type.remote_video
+    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
 id: node.project.field_lower_content
@@ -22,94 +39,132 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
+      text: text
+      columns: columns
+      accordion: accordion
+      image: image
       list_of_links: list_of_links
+      content_cards: content_cards
+      content_liftup: content_liftup
+      banner: banner
+      unit_search: unit_search
+      from_library: from_library
+      chart: chart
+      event_list: event_list
+      news_list: news_list
+      contact_card_listing: contact_card_listing
+      map: map
+      remote_video: remote_video
+      list_of_plans: list_of_plans
+      phasing: phasing
     negate: 0
     target_bundles_drag_drop:
       accordion:
-        weight: 30
-        enabled: false
+        weight: -71
+        enabled: true
       accordion_item:
-        weight: 31
+        weight: -66
         enabled: false
       banner:
-        weight: 32
-        enabled: false
+        weight: -64
+        enabled: true
       chart:
-        weight: 33
-        enabled: false
+        weight: -57
+        enabled: true
       columns:
-        weight: 34
-        enabled: false
+        weight: -72
+        enabled: true
       contact_card:
-        weight: 35
+        weight: -56
         enabled: false
       contact_card_listing:
-        weight: 36
-        enabled: false
+        weight: -52
+        enabled: true
       content_cards:
-        weight: 37
-        enabled: false
+        weight: -67
+        enabled: true
       content_liftup:
-        weight: 38
+        weight: -65
+        enabled: true
+      district_and_project_search:
+        weight: -48
+        enabled: false
+      district_listing:
+        weight: -45
         enabled: false
       event_list:
-        weight: 39
-        enabled: false
+        weight: -55
+        enabled: true
       from_library:
-        weight: 40
-        enabled: false
+        weight: -58
+        enabled: true
       gallery:
-        weight: 41
+        weight: -69
         enabled: false
       gallery_slide:
-        weight: 42
+        weight: -63
         enabled: false
       hero:
-        weight: 43
+        weight: -62
         enabled: false
       image:
-        weight: 44
-        enabled: false
+        weight: -70
+        enabled: true
       liftup_with_image:
-        weight: 45
+        weight: -61
         enabled: false
       list_of_links:
-        weight: 46
+        weight: -68
         enabled: true
       list_of_links_item:
-        weight: 47
+        weight: -60
         enabled: false
       list_of_plans:
-        weight: 48
-        enabled: false
+        weight: -49
+        enabled: true
       map:
-        weight: 49
-        enabled: false
+        weight: -51
+        enabled: true
       news_list:
-        weight: 50
-        enabled: false
+        weight: -54
+        enabled: true
       phasing:
-        weight: 51
-        enabled: false
+        weight: -43
+        enabled: true
       phasing_item:
-        weight: 52
+        weight: -53
+        enabled: false
+      popular_service_item:
+        weight: -42
+        enabled: false
+      popular_services:
+        weight: -41
+        enabled: false
+      project_listing:
+        weight: -40
         enabled: false
       remote_video:
-        weight: 53
-        enabled: false
+        weight: -50
+        enabled: true
       service_list:
-        weight: 54
+        weight: -47
         enabled: false
       sidebar_text:
-        weight: 55
+        weight: -44
         enabled: false
       social_media_link:
-        weight: 56
+        weight: -46
+        enabled: false
+      target_group_link_item:
+        weight: -39
+        enabled: false
+      target_group_links:
+        weight: -38
         enabled: false
       text:
-        weight: 57
-        enabled: false
+        weight: -73
+        enabled: true
       unit_search:
-        weight: 58
-        enabled: false
+        weight: -59
+        enabled: true
 field_type: entity_reference_revisions


### PR DESCRIPTION
# [UHF-6506](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6506)
<!-- What problem does this solve? -->
The district and project pages should have few more paragraphs available.

## What was done
<!-- Describe what was done -->

* Enabled some paragraphs to district and project content types.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6506_district_and_project_paragraphs_same_as_standard_page`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that district page has now list of links, banner, columns and reusable paragraphs available on the upper content field. You might want to test the paragraphs that they work correctly on the content.
* [x] Check that project page has now image, banner, columns and reusable paragraphs available on the upper content field. You might want to test the paragraphs that they work correctly on the content.
* [ ] Check that code follows our standards.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review