### PR TITLE
UHF-6325: Replace chat blocks with leijuke.

### DIFF
--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -19,7 +19,7 @@ settings:
   label: 'Chat Leijuke Smartti'
   label_display: '0'
   provider: helfi_platform_config
-  chat_title: 'Kysy pysäköinnistä robotilta'
+  chat_title: 'Ask the robot about parking'
   chat_selection: smartti_chatbot
 visibility:
   language:

--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -1,4 +1,4 @@
-uuid: da673ab8-312a-4fe0-ade7-09146c991093
+uuid: 0118e18f-ecc0-4df2-b316-e768399b228e
 langcode: en
 status: true
 dependencies:
@@ -8,23 +8,25 @@ dependencies:
     - system
   theme:
     - hdbt_subtheme
-id: hdbt_subtheme_smarttichatbot
+id: chatleijuke
 theme: hdbt_subtheme
 region: attachments
-weight: -11
+weight: -12
 provider: null
-plugin: smartti_chatbot
+plugin: chat_leijuke
 settings:
-  id: smartti_chatbot
-  label: 'Smartti Chatbot'
+  id: chat_leijuke
+  label: 'Chat Leijuke Smartti'
   label_display: '0'
   provider: helfi_platform_config
+  chat_title: 'Kysy pysäköinnistä robotilta'
+  chat_selection: smartti_chatbot
 visibility:
   language:
     id: language
     negate: false
     context_mapping:
-      language: '@language.current_language_context:language_content'
+      language: '@language.current_language_context:language_interface'
     langcodes:
       fi: fi
   request_path:

--- a/conf/cmi/block.block.chatleijuke_2.yml
+++ b/conf/cmi/block.block.chatleijuke_2.yml
@@ -19,7 +19,7 @@ settings:
   label: 'Chat Leijuke Genesys KYMP'
   label_display: '0'
   provider: helfi_platform_config
-  chat_title: 'Pysäköinnin asiakaspalvelun chat'
+  chat_title: 'Parking customer service chat'
   chat_selection: genesys_kymp
 visibility:
   language:

--- a/conf/cmi/block.block.chatleijuke_2.yml
+++ b/conf/cmi/block.block.chatleijuke_2.yml
@@ -1,4 +1,4 @@
-uuid: ccd00b9b-c6c0-438c-8b7a-2adb861fcda5
+uuid: 934d8fea-d507-4a7c-8752-c2ea49a68027
 langcode: en
 status: true
 dependencies:
@@ -8,23 +8,25 @@ dependencies:
     - system
   theme:
     - hdbt_subtheme
-id: hdbt_subtheme_genesyschat
+id: chatleijuke_2
 theme: hdbt_subtheme
 region: attachments
-weight: -10
+weight: -13
 provider: null
-plugin: genesys_chat
+plugin: chat_leijuke
 settings:
-  id: genesys_chat
-  label: 'Genesys Chat'
+  id: chat_leijuke
+  label: 'Chat Leijuke Genesys KYMP'
   label_display: '0'
   provider: helfi_platform_config
+  chat_title: 'Pysäköinnin asiakaspalvelun chat'
+  chat_selection: genesys_kymp
 visibility:
   language:
     id: language
     negate: false
     context_mapping:
-      language: '@language.current_language_context:language_content'
+      language: '@language.current_language_context:language_interface'
     langcodes:
       fi: fi
   request_path:

--- a/conf/cmi/language/fi/block.block.chatleijuke.yml
+++ b/conf/cmi/language/fi/block.block.chatleijuke.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Kysy pysäköinnistä robotilta'

--- a/conf/cmi/language/fi/block.block.chatleijuke_2.yml
+++ b/conf/cmi/language/fi/block.block.chatleijuke_2.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Pysäköinnin asiakaspalvelun chat'

--- a/conf/cmi/language/sv/block.block.chatleijuke.yml
+++ b/conf/cmi/language/sv/block.block.chatleijuke.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Fråga roboten om parkering'

--- a/conf/cmi/language/sv/block.block.chatleijuke_2.yml
+++ b/conf/cmi/language/sv/block.block.chatleijuke_2.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Parkering kundtjänst chatt'


### PR DESCRIPTION
# [UHF-6325](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6325)
<!-- What problem does this solve? -->
Replaces chat blocks with leijuke.
## What was done
<!-- Describe what was done -->

* Updated platform config and theme.
* Replaced chat blocks with leijuke blocks.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6325-chat-via-leijuke`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works by visiting /pysakointi page and interacting with the chat leijuke.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
