### PR TITLE
UHF-6557: Subdistrict sidebar cache

### DIFF
--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
@@ -5,11 +5,27 @@
  * Contains alterations for content.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
 use Drupal\helfi_kymp_content\DistrictUtility;
 use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_theme().
+ */
+function helfi_kymp_content_theme() {
+  return [
+    'subdistricts_navigation' => [
+      'variables' => [
+        'navigation' => NULL,
+        'parent_title' => NULL,
+        'parent_url' => NULL,
+      ],
+    ],
+  ];
+}
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -169,6 +185,50 @@ function _helfi_kymp_content_create_district_nodes_from_taxonomy_terms() {
         $node_translation->save();
       }
     }
+  }
+}
+
+/**
+ * Implements hook_node_update().
+ */
+function helfi_kymp_content_node_update(NodeInterface $node) {
+  if ($node->getType() === 'district') {
+    _helfi_kymp_content_invalidate_subdistricts($node);
+  }
+}
+
+/**
+ * Implements hook_node_insert().
+ */
+function helfi_kymp_content_node_insert(NodeInterface $node) {
+  if ($node->getType() === 'district') {
+    _helfi_kymp_content_invalidate_subdistricts($node);
+  }
+}
+
+/**
+ * Implements hook_node_delete().
+ */
+function helfi_kymp_content_node_delete(NodeInterface $node) {
+  if ($node->getType() === 'district') {
+    _helfi_kymp_content_invalidate_subdistricts($node);
+  }
+}
+
+/**
+ * Invalidate cache for nodes that are referenced as sub-districts.
+ */
+function _helfi_kymp_content_invalidate_subdistricts(NodeInterface $node) {
+  if (!$node->hasField('field_subdistricts')) {
+    return;
+  }
+
+  $subdistricts = $node->get('field_subdistricts')->referencedEntities();
+  foreach ($subdistricts as $subdistrict) {
+    if (!$subdistrict instanceof NodeInterface) {
+      continue;
+    }
+    Cache::invalidateTags(['node:' . $subdistrict->id()]);
   }
 }
 

--- a/public/modules/custom/helfi_kymp_content/src/DistrictUtility.php
+++ b/public/modules/custom/helfi_kymp_content/src/DistrictUtility.php
@@ -24,14 +24,18 @@ class DistrictUtility {
    *   The array containing the parent node IDs.
    */
   public static function getSubdistrictParentIds(NodeInterface $node): array {
-    return \Drupal::entityQuery('node')
+    $query = \Drupal::entityQuery('node')
       ->accessCheck(TRUE)
       ->condition('type', 'district')
-      ->condition('status', NodeInterface::PUBLISHED)
       ->condition('langcode', $node->language()->getId())
       ->exists('field_subdistricts')
-      ->condition('field_subdistricts.entity:node.nid', $node->id())
-      ->execute();
+      ->condition('field_subdistricts.entity:node.nid', $node->id());
+
+    if (!\Drupal::currentUser()->isAuthenticated()) {
+      $query->condition('status', NodeInterface::PUBLISHED);
+    }
+
+    return $query->execute();
   }
 
 }

--- a/public/modules/custom/helfi_kymp_content/src/Plugin/Block/SubdistrictsNavigationBlock.php
+++ b/public/modules/custom/helfi_kymp_content/src/Plugin/Block/SubdistrictsNavigationBlock.php
@@ -167,6 +167,11 @@ class SubdistrictsNavigationBlock extends BlockBase implements ContainerFactoryP
           continue;
         }
 
+        // Do not show unpublished subdistrict for anonymous users.
+        if (!\Drupal::currentUser()->isAuthenticated() && !$subdistrict->getTranslation($currentLanguageId)->isPublished()) {
+          continue;
+        }
+
         // Set sub-district menu item.
         $navigation[$menuItem]['below'][$subdistrict->id()] = [
           'title' => $subdistrict->getTranslation($currentLanguageId)->label(),
@@ -186,6 +191,11 @@ class SubdistrictsNavigationBlock extends BlockBase implements ContainerFactoryP
           $navigation[$menuItem]['below'][$subdistrict->id()]['in_active_trail'] = TRUE;
         }
       }
+
+      // Clear parent menu item if there is no sub-items.
+      if (empty($navigation[$menuItem]['below'])) {
+        unset($navigation[$menuItem]);
+      }
     }
 
     return [
@@ -203,6 +213,7 @@ class SubdistrictsNavigationBlock extends BlockBase implements ContainerFactoryP
     return Cache::mergeContexts(parent::getCacheContexts(), [
       'url.path',
       'languages:language_content',
+      'user.permissions',
     ]);
   }
 

--- a/public/modules/custom/helfi_kymp_content/src/Plugin/Block/SubdistrictsNavigationBlock.php
+++ b/public/modules/custom/helfi_kymp_content/src/Plugin/Block/SubdistrictsNavigationBlock.php
@@ -191,8 +191,8 @@ class SubdistrictsNavigationBlock extends BlockBase implements ContainerFactoryP
     return [
       '#theme' => 'subdistricts_navigation',
       '#navigation' => $navigation,
-      'parent_title' => $parentTitle,
-      'parent_url' => $parentUrl,
+      '#parent_title' => $parentTitle,
+      '#parent_url' => $parentUrl,
     ];
   }
 
@@ -201,9 +201,7 @@ class SubdistrictsNavigationBlock extends BlockBase implements ContainerFactoryP
    */
   public function getCacheContexts(): array {
     return Cache::mergeContexts(parent::getCacheContexts(), [
-      'user.permissions',
       'url.path',
-      'url.query_args',
       'languages:language_content',
     ]);
   }

--- a/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
@@ -2,10 +2,10 @@
 
 <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }} class="sidebar-navigation">
   <h2{{ title_attributes.setAttribute('id', heading_id) }} class="sidebar-navigation__title">
-    {{ link(content['parent_title'], 'base:' ~ content['parent_url']) }}
+    {{ link(parent_title, 'base:' ~ parent_url) }}
   </h2>
   {% block content %}
-    {% set items = content['#navigation'] %}
+    {% set items = navigation %}
     {% embed "@hdbt/navigation/menu.html.twig" with {auto_open: true, allow_collabsible: true} %}{% endembed %}
   {% endblock %}
 </nav>


### PR DESCRIPTION
# [UHF-6557](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6557)
<!-- What problem does this solve? -->

## What was done
* Fixed the cache invalidation when adding and editing districts with sub-districts.
* Allowing content editors to see the sub-district sidebar navigation with unpublished content.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6557-subdistrict-sidebar-cache`
  * `make fresh`
* Run `make drush-cr`

## How to test
### Caching
* First, make sure you have enabled caching with your local environment.
* Create a district and publish it ("District A").
* Create another district and publish it also ("District B").
* Edit "District A" and add the "District B" as its sub-district.
* Check that the "District B" page is updated with the sidebar navigation that shows "District A" as a parent item.

### Editor view
* First, browse the "District A" and "District B" pages as anonymous user by opening them with another browser.
* Unpublish the "District A" page.
* With logged-in user, you should still see "District A" at the sidebar navigation when viewing "District B" page.
* With anonymous user, you should not see the sidebar navigation when viewing "District B" page.

### Other testing
* You can also try different combinations e.g. by translating districts and adding other sub-districts.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)