### PR TITLE
UHF-7499: Print district information on project page even if the dist…

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -86,5 +87,24 @@ function hdbt_subtheme_preprocess_node(array &$variables) {
   $config = \Drupal::config('elastic_proxy.settings');
   if ($config->get('elastic_proxy_url')) {
     $variables['#attached']['drupalSettings']['helfi_kymp_district_project_search']['elastic_proxy_url'] = $config->get('elastic_proxy_url');
+  }
+
+  // On project nodes print out the districts even if they are unpublished.
+  if ($variables['node']->getType() === 'project') {
+    $node = $variables['node'];
+    $districts = $node->get('field_project_district')->getValue();
+    $district_titles = [];
+    foreach ($districts as $district) {
+      $district_node_id = $district['target_id'];
+      $district_node = Node::load($district_node_id);
+      $district_title = $district_node->getTitle();
+
+      if ($district_node->hasTranslation($variables['current_langcode'])) {
+        $district_title = $district_node->getTranslation($variables['current_langcode'])->getTitle();
+      }
+
+      $district_titles[] = $district_title;
+    }
+    $variables['district_titles'] = implode(', ', $district_titles);
   }
 }

--- a/public/themes/custom/hdbt_subtheme/templates/content/node--project--full.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/node--project--full.html.twig
@@ -67,7 +67,7 @@
       { label: 'Project phase'|t, icon: 'calendar-clock', content: content.field_project_phase },
       { label: 'Project theme'|t, icon: 'locate', content: content.field_project_theme },
       { label: schedule_label, icon: 'calendar', content: schedule_content },
-      { label: 'Project location'|t, icon: 'location', content: content.field_project_district }
+      { label: 'Project location'|t, icon: 'location', content: district_titles }
     ] %}
 
     <div class="project__metadata-wrapper">


### PR DESCRIPTION
…rict node in question is unpublished

# [UHF-7499](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7499)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Displays district information on project node for anonymous user even if the districts in question are unpublished.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7499_project_page_location_visibility_for_unpublished_district`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] As an anonymous user go to a project page that has unpublished districts set as it s project district. For example `https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/kaupunkisuunnittelu-ja-rakentaminen/hae-suunnitelmia-ja-hankkeita/kruunusillat`. You should be able to see all districts on the "Location" field even tho some of them are unpublished. Previously the unpublished ones were visible only to logged in users.
* [ ] Test also different language-versions. 
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
