### PR TITLE
UHF-7746: Fix error when field has reference to removed district

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -96,7 +96,9 @@ function hdbt_subtheme_preprocess_node(array &$variables) {
     $district_titles = [];
     foreach ($districts as $district) {
       $district_node_id = $district['target_id'];
-      $district_node = Node::load($district_node_id);
+      if (!$district_node = Node::load($district_node_id)) {
+        continue;
+      }
       $district_title = $district_node->getTitle();
 
       if ($district_node->hasTranslation($variables['current_langcode'])) {


### PR DESCRIPTION
# [UHF-7746](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7746)
<!-- What problem does this solve? -->

## What was done
* Fixed an error when field had a reference to a removed district.

## Set-up before using the fix

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout dev`
  * `make fresh`
* Run `make drush-cr`

## How to reproduce the error

* Create a new district.
* Add the district to a project:
  * Edit some project.
  * Add the district to a project using the Project district field.
* Delete the district content.
* Clear caches: `drush cr`
* Try to open the project page. You should see an error.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout UHF-7746-fix-project-district-error`
* Run `make drush-cr`

## How to test

* Again, try to open the same project page as before. Now the page should work.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)