### PR TITLE
UHF-7612: Subdistrict navigation bug

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
@@ -26,7 +26,7 @@
   <div class="section-navigation__menu-wrapper" id=" {{ section_menu_aria_controls }}">
     {% block content %}
       {% set items = navigation %}
-      {% set menu_depth = 5 %}
+      {% set menu_depth = 5 %} {# TODO: This should be set globally. #}
       {% embed "@hdbt/navigation/menu.html.twig" with {auto_open: true, allow_collabsible: true} %}{% endembed %}
     {% endblock %}
   </div>

--- a/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
@@ -26,6 +26,7 @@
   <div class="section-navigation__menu-wrapper" id=" {{ section_menu_aria_controls }}">
     {% block content %}
       {% set items = navigation %}
+      {% set menu_depth = 5 %}
       {% embed "@hdbt/navigation/menu.html.twig" with {auto_open: true, allow_collabsible: true} %}{% endembed %}
     {% endblock %}
   </div>


### PR DESCRIPTION
## What was done
Fixed missing subdistrict links on district page navigation.

## How to install
1. Set up KYMP instance
2. Checkout this branch: `git checkout UHF-7612_subdistrict_navigation_bug`
3. Clear cache: `make drush-cr`

## How to test
1. Create (or view existing) district node with one or more subdistricts
2. Make sure that the links to the subdistrict nodes are visible in the left side navigation