### PR TITLE
UHF-7566: news update every 30 minutes

### DIFF
--- a/conf/cmi/external_entities.external_entity_type.helfi_news.yml
+++ b/conf/cmi/external_entities.external_entity_type.helfi_news.yml
@@ -34,8 +34,8 @@ field_mapper_config:
     short_title:
       value: '$.attributes[''short_title'']'
 storage_client_id: helfi_news
-storage_client_config: {  }
-persistent_cache_max_age: 10800
+storage_client_config: null
+persistent_cache_max_age: 1800
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null


### PR DESCRIPTION
# [UHF-7566](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7566)
News feed updated with too long delay

## What was done
lowered cache time to 3 hours

## How to install
* Add this line to your local.settings.php 
  * `$config['helfi_news_feed.settings']['source_environment'] = 'local';`
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7566_news_update`
  * `make fresh`
* Change the news external entity cache time to as short as you feel comfortable testing with `/admin/structure/external-entity-types/helfi_news`
* Run `make drush-cr`

* Setup etusivu instance in order to get the news-feed from local environment

## How to test
* Add `new page` with `news_list` paragraph with a `news_tag` `Terveys ja sosiaalipalvelut` 
* Load the page: the feed should be working and show you a certain set of news from your local etusivu-instance
* Now go to your local Etusivu-instance and add new news item and tag it with `Terveys ja sosiaalipalvelut`
* Wait for the cache to expire (the time you hopefully updated manually earlier)
* Run `make shell` and `drush cron` on the receiving instance (KYMP)
* `Refresh the page` with news feed: it should have updated with the news item you just created



[UHF-7566]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ