### PR TITLE
UHF-8019: District content type metadescription fix

### DIFF
--- a/conf/cmi/core.entity_form_display.node.district.default.yml
+++ b/conf/cmi/core.entity_form_display.node.district.default.yml
@@ -115,7 +115,7 @@ content:
     weight: 22
     region: content
     settings:
-      sidebar: true
+      sidebar: false
       use_details: true
     third_party_settings: {  }
   field_sidebar_content:

--- a/conf/cmi/metatag.metatag_defaults.node__district.yml
+++ b/conf/cmi/metatag.metatag_defaults.node__district.yml
@@ -1,0 +1,8 @@
+uuid: f2dd9585-e615-4ff9-aa5f-afd1464ace56
+langcode: en
+status: true
+dependencies: {  }
+id: node__district
+label: 'Content: District'
+tags:
+  description: '[node:field_hero:entity:field_hero_desc]'

--- a/conf/cmi/metatag.settings.yml
+++ b/conf/cmi/metatag.settings.yml
@@ -16,6 +16,10 @@ entity_type_groups:
       basic: basic
       open_graph: open_graph
       twitter_cards: twitter_cards
+    district:
+      basic: basic
+      open_graph: open_graph
+      twitter_cards: twitter_cards
     landing_page:
       basic: basic
       open_graph: open_graph
@@ -24,3 +28,16 @@ entity_type_groups:
       basic: basic
       open_graph: open_graph
       twitter_cards: twitter_cards
+tag_trim_method: beforeValue
+tag_trim_maxlength:
+  metatag_maxlength_title: null
+  metatag_maxlength_description: null
+  metatag_maxlength_abstract: null
+  metatag_maxlength_og_description: null
+  metatag_maxlength_og_site_name: null
+  metatag_maxlength_og_title: null
+  metatag_maxlength_twitter_cards_label2: null
+  metatag_maxlength_twitter_cards_label1: null
+  metatag_maxlength_twitter_cards_description: null
+  metatag_maxlength_twitter_cards_title: null
+tag_scroll_max_height: ''


### PR DESCRIPTION
# [UHF-8019](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8019)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added correct default value for district content type metadescription field

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8019_district_content_type_metadescrition_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to any district page that has hero-block with text inside the hero (not just the title) and make sure that the meta description of that page is now the same as the hero-text. If there isn't one with hero and text, edit or create one.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8019]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ