### PR TITLE
UHF-8290: added missing language type

### DIFF
--- a/public/modules/custom/helfi_kymp_content/src/DistrictUtility.php
+++ b/public/modules/custom/helfi_kymp_content/src/DistrictUtility.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_kymp_content;
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -43,7 +44,9 @@ class DistrictUtility {
     // @todo Get translated entity reference field value using the entity query
     // above, if possible.
     $parentIds = [];
-    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $langcode = \Drupal::languageManager()
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+      ->getId();
     foreach ($query->execute() as $parentId) {
       if (!\Drupal::entityTypeManager()->getStorage('node')->load($parentId)->hasTranslation($langcode)) {
         continue;

--- a/public/modules/custom/helfi_kymp_content/src/Plugin/Block/SubdistrictsNavigationBlock.php
+++ b/public/modules/custom/helfi_kymp_content/src/Plugin/Block/SubdistrictsNavigationBlock.php
@@ -6,6 +6,7 @@ namespace Drupal\helfi_kymp_content\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Path\CurrentPathStack;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -107,7 +108,9 @@ class SubdistrictsNavigationBlock extends BlockBase implements ContainerFactoryP
    * {@inheritdoc}
    */
   public function build(): array {
-    $currentLanguageId = $this->languageManager->getCurrentLanguage()->getId();
+    $currentLanguageId = $this->languageManager
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+      ->getId();
 
     // Get currently viewed district node.
     $translatedNode = $this->routeMatch->getParameter('node')->getTranslation($currentLanguageId);


### PR DESCRIPTION
## Custom modules

Added missing content language parameter to subdistrict block. Both changes are within the subdistrict block.

It seems that the subdistrict block is disabled everywhere.