### PR TITLE
UHF-8390 D10 deprecation

### DIFF
--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
@@ -142,10 +142,12 @@ function _helfi_kymp_content_create_district_nodes_from_taxonomy_terms() {
   $entity_type_manager = \Drupal::entityTypeManager();
   $term_storage = $entity_type_manager->getStorage('taxonomy_term');
 
-  $query = $term_storage->getQuery();
-  $query->condition('vid', $vocabulary);
-  $query->condition('langcode', $original_lang);
-  $tids = $query->execute();
+  $tids = $term_storage->getQuery()
+  ->condition('vid', $vocabulary)
+  ->condition('langcode', $original_lang)
+  ->accessCheck(FALSE)
+  ->execute();
+
   $terms = $term_storage->loadMultiple($tids);
 
   foreach ($terms as $term) {

--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
@@ -143,10 +143,10 @@ function _helfi_kymp_content_create_district_nodes_from_taxonomy_terms() {
   $term_storage = $entity_type_manager->getStorage('taxonomy_term');
 
   $tids = $term_storage->getQuery()
-  ->condition('vid', $vocabulary)
-  ->condition('langcode', $original_lang)
-  ->accessCheck(FALSE)
-  ->execute();
+    ->condition('vid', $vocabulary)
+    ->condition('langcode', $original_lang)
+    ->accessCheck(FALSE)
+    ->execute();
 
   $terms = $term_storage->loadMultiple($tids);
 

--- a/public/modules/custom/helfi_kymp_migrations/helfi_kymp_migrations.info.yml
+++ b/public/modules/custom/helfi_kymp_migrations/helfi_kymp_migrations.info.yml
@@ -1,6 +1,5 @@
 name: 'HELfi KYMP Migration'
 type: module
 description: 'Migrates project taxonomies'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 package: HELfi

--- a/public/modules/custom/helfi_kymp_plans/helfi_kymp_plans.info.yml
+++ b/public/modules/custom/helfi_kymp_plans/helfi_kymp_plans.info.yml
@@ -2,8 +2,7 @@ name: 'HELfi KYMP Plans'
 type: module
 description: 'Fetch a list of plans from a RSS feed and display them in a paragraph.'
 package: HELfi
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - paragraphs
 'interface translation project': helfi_kymp_plans

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
@@ -3,7 +3,7 @@ description: Subtheme for Helsinki Drupal instances.
 type: theme
 base theme: hdbt
 tags: sub-theme
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 screenshot: hdbt_subtheme.png
 'interface translation project': hdbt_subtheme
 'interface translation server pattern': themes/custom/hdbt_subtheme/translations/%language.po


### PR DESCRIPTION
Updated core version requirements
Added access check to entity query

How to test:
Setup the site normally
Go to front page and admin side status page
The site should work

You can also test the D10 readiness status by following these steps:
run `composer require drupal/upgrade_status` and `drush en -y upgrade_status`

Running these commands below should only yield prophesy/prophesize errors:
for all custom modules run `drush upgrade_status:analyze helfi_custom_module_name_here`
run `drush upgrade_status:analyze hdbt_subtheme`