### PR TITLE
UHF-8607: remove useless module

### DIFF
--- a/public/modules/custom/helfi_kymp_district_project_search/helfi_kymp_district_project_search.info.yml
+++ b/public/modules/custom/helfi_kymp_district_project_search/helfi_kymp_district_project_search.info.yml
@@ -1,4 +1,0 @@
-name: HELfi District and project search
-description: Module for rendering District and project search react app
-type: module
-core_version_requirement: '^8.9 || ^9'


### PR DESCRIPTION
# [UHF-8607](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8607)

Deleted module files which was disabled on 14.6. production deployment

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8607`
  * `make fresh`
* Run `make drush-cr`

## How to test

Make fresh
- status page should load without problems


[UHF-8607]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ