### PR TITLE
UHF-3592: Set nodes unpublished as default

### DIFF
--- a/conf/cmi/core.base_field_override.node.district.status.yml
+++ b/conf/cmi/core.base_field_override.node.district.status.yml
@@ -8,7 +8,7 @@ id: node.district.status
 field_name: status
 entity_type: node
 bundle: district
-label: Julkaistu
+label: Published
 description: ''
 required: false
 translatable: true

--- a/conf/cmi/core.base_field_override.node.district.status.yml
+++ b/conf/cmi/core.base_field_override.node.district.status.yml
@@ -1,5 +1,5 @@
 uuid: 5afac56f-67ff-4ebf-a7fa-9f7315d63b47
-langcode: fi
+langcode: en
 status: true
 dependencies:
   config:
@@ -17,6 +17,6 @@ default_value:
     value: 0
 default_value_callback: ''
 settings:
-  on_label: Käytössä
-  off_label: 'Pois päältä'
+  on_label: On
+  off_label: Off
 field_type: boolean

--- a/conf/cmi/core.base_field_override.node.district.status.yml
+++ b/conf/cmi/core.base_field_override.node.district.status.yml
@@ -1,0 +1,22 @@
+uuid: 5afac56f-67ff-4ebf-a7fa-9f7315d63b47
+langcode: fi
+status: true
+dependencies:
+  config:
+    - node.type.district
+id: node.district.status
+field_name: status
+entity_type: node
+bundle: district
+label: Julkaistu
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Käytössä
+  off_label: 'Pois päältä'
+field_type: boolean

--- a/conf/cmi/core.base_field_override.node.project.status.yml
+++ b/conf/cmi/core.base_field_override.node.project.status.yml
@@ -1,0 +1,22 @@
+uuid: 0e78cc9a-cfa4-4c4f-bf71-eec0b92f8430
+langcode: fi
+status: true
+dependencies:
+  config:
+    - node.type.project
+id: node.project.status
+field_name: status
+entity_type: node
+bundle: project
+label: Julkaistu
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Käytössä
+  off_label: 'Pois päältä'
+field_type: boolean

--- a/conf/cmi/core.base_field_override.node.project.status.yml
+++ b/conf/cmi/core.base_field_override.node.project.status.yml
@@ -8,7 +8,7 @@ id: node.project.status
 field_name: status
 entity_type: node
 bundle: project
-label: Julkaistu
+label: Published
 description: ''
 required: false
 translatable: true

--- a/conf/cmi/core.base_field_override.node.project.status.yml
+++ b/conf/cmi/core.base_field_override.node.project.status.yml
@@ -1,5 +1,5 @@
 uuid: 0e78cc9a-cfa4-4c4f-bf71-eec0b92f8430
-langcode: fi
+langcode: en
 status: true
 dependencies:
   config:
@@ -17,6 +17,6 @@ default_value:
     value: 0
 default_value_callback: ''
 settings:
-  on_label: Käytössä
-  off_label: 'Pois päältä'
+  on_label: On
+  off_label: Off
 field_type: boolean


### PR DESCRIPTION
# [UHF-3592](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3592)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Set nodes unpublished as default

## How to install

* These instructions contains also changes from platform-config PR, hence those are related to the issue
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-3592_Nodes_unpublished_as_default`
  * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-3592_Nodes_default_unpublish`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] All content types are set to unpublished when creating a new content
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* [UHF-3592: Set nodes as unpublish on default `platform-config`](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/541)


[UHF-3592]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-3592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ