### PR TITLE
UHF-8515: Add district content type nodes to sitemap

### DIFF
--- a/conf/cmi/simple_sitemap.bundle_settings.default.node.district.yml
+++ b/conf/cmi/simple_sitemap.bundle_settings.default.node.district.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false


### PR DESCRIPTION
# [UHF-8515](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8515)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Included district content to sitemap.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8515_district_pages_to_sitemap`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://helfi-kymp.docker.so/en/urban-environment-and-traffic/admin/config/search/simplesitemap and click on the "Rebuild queue & generate" button and the sitemap should be rebuild with now the district nodes also included.
* [ ] Go to any district node, check the url of the node and open `https://helfi-kymp.docker.so/sitemap.xml` Search for the url of the district node and it should be found from the sitemap now along with all the other content that was already there.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
