### PR TITLE
UHF-X: Fix crash on site install

### DIFF
--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.info.yml
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.info.yml
@@ -5,3 +5,5 @@ core_version_requirement: ^9 || ^10
 package: HELfi
 'interface translation project': helfi_kymp_content
 'interface translation server pattern': modules/custom/helfi_kymp_content/translations/%language.po
+dependencies:
+    - search_api:search_api


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

At the moment, artifact generation fails silently due to module loading order issue. This adds `search_api` as a dependency to `helfi_kymp_content` module, so that class `Drupal\search_api\Event\SearchApiEvents` is present when `Drupal\helfi_kymp_content\EventSubscriber\SearchApiSubscriber::getSubscribedEvents` is called.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-fix-crash-on-site-install`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run commands from [artifact.yml](https://github.com/City-of-Helsinki/drupal-helfi-kymp/blob/dev/.github/workflows/artifact.yml)
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Artifact generation has not worked since #720. 
