### PR TITLE
UHF-9356: Subdistrict navigation layout fix

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/subdistricts-navigation.html.twig
@@ -8,6 +8,7 @@
     <div{{ title_attributes.setAttribute('id', heading_id) }} class="sidebar-navigation__title section-navigation__title">
       {% set link_attributes = {
         'id': section_menu_title_link,
+        'class': 'sidebar-navigation__title-link',
       } %}
       {{ link(parent_title, 'base:' ~ parent_url, link_attributes) }}
     </div>


### PR DESCRIPTION
# [UHF-9356](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9356)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9356`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to a district page for example like this: https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/kaupunkisuunnittelu-ja-rakentaminen/uutta-helsinkia-rakentamassa/kalasatama that has subdistricts defined so that the sidebar navigation becomes visible. Now the layout should be fixed on the navigation in desktop and mobile. Correct layout looks similar to this: https://www.hel.fi/fi/kasvatus-ja-koulutus/alppilan-lukio/opiskelu. The broken navigation can be seen here on the testing site https://www.hel.fi/fi/test-kaupunkiymparisto-ja-liikenne/kaupunkisuunnittelu-ja-rakentaminen/uutta-helsinkia-rakentamassa/kalasatama
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-9356]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ