### PR TITLE
UHF-8020: run search api rebuild and index once a day

### DIFF
--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -40,6 +40,7 @@ exec "/crons/update-translations.sh" &
 exec "/crons/content-scheduler.sh" &
 exec "/crons/invalidate-tags-kymp.sh" &
 exec "/crons/pubsub.sh" &
+exec "/crons/street-data.sh" &
 
 while true
 do

--- a/docker/openshift/crons/street-data.sh
+++ b/docker/openshift/crons/street-data.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Start indexing street data from external datasource: $(date)"
+
+while true
+do
+  drush sapi-r && drush sapi-i
+  sleep 86400
+done

--- a/docker/openshift/crons/street-data.sh
+++ b/docker/openshift/crons/street-data.sh
@@ -4,6 +4,6 @@ echo "Start indexing street data from external datasource: $(date)"
 
 while true
 do
-  drush sapi-r && drush sapi-i
+  drush sapi-r street_data && drush sapi-i street_data
   sleep 86400
 done


### PR DESCRIPTION
# [UHF-8020](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8020)

## What was done
Added cron to reindex the index using external datasource

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8020_street_data_cron`
  * `make fresh`
* Run `make drush-cr`

## How to test
After setup, run street data cron
Go check street data index. It should have the items.



[UHF-8020]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ