### PR TITLE
UHF-9347: Change path alias patterns for projects

### DIFF
--- a/conf/cmi/pathauto.pattern.project_content_pattern_en.yml
+++ b/conf/cmi/pathauto.pattern.project_content_pattern_en.yml
@@ -8,20 +8,20 @@ dependencies:
 id: project_content_pattern_en
 label: 'Project content pattern (EN)'
 type: 'canonical_entities:node'
-pattern: 'urban-planning-and-construction/search-plans-and-projects/[node:title]'
+pattern: 'urban-planning-and-construction/plans-and-building-projects/[node:title]'
 selection_criteria:
-  080bb49a-c671-48f8-8a55-6459b300e241:
+  41be5d22-a3e7-4fbd-ada2-a757d872b4fa:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 080bb49a-c671-48f8-8a55-6459b300e241
+    uuid: 41be5d22-a3e7-4fbd-ada2-a757d872b4fa
     context_mapping:
       node: node
     bundles:
       project: project
-  7ffe4fb5-9c01-4f09-bf61-37310d10a833:
+  9a0d4821-9ad5-44cd-9f3a-aff841512a74:
     id: language
     negate: false
-    uuid: 7ffe4fb5-9c01-4f09-bf61-37310d10a833
+    uuid: 9a0d4821-9ad5-44cd-9f3a-aff841512a74
     context_mapping:
       language: 'node:langcode:language'
     langcodes:

--- a/conf/cmi/pathauto.pattern.project_content_pattern_fi.yml
+++ b/conf/cmi/pathauto.pattern.project_content_pattern_fi.yml
@@ -8,20 +8,20 @@ dependencies:
 id: project_content_pattern_fi
 label: 'Project content pattern (FI)'
 type: 'canonical_entities:node'
-pattern: 'kaupunkisuunnittelu-ja-rakentaminen/hae-suunnitelmia-ja-hankkeita/[node:title]'
+pattern: 'kaupunkisuunnittelu-ja-rakentaminen/suunnitelmat-ja-rakennushankkeet/[node:title]'
 selection_criteria:
-  9a633b22-53b4-4106-9806-d087740687eb:
+  b87914d9-fc7d-4916-b015-1ea077744583:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 9a633b22-53b4-4106-9806-d087740687eb
+    uuid: b87914d9-fc7d-4916-b015-1ea077744583
     context_mapping:
       node: node
     bundles:
       project: project
-  2cce6ebc-19ed-449d-b0e3-3fb513413f6c:
+  44ec2474-d4e6-4331-8c3c-556d4e195ec5:
     id: language
     negate: false
-    uuid: 2cce6ebc-19ed-449d-b0e3-3fb513413f6c
+    uuid: 44ec2474-d4e6-4331-8c3c-556d4e195ec5
     context_mapping:
       language: 'node:langcode:language'
     langcodes:

--- a/conf/cmi/pathauto.pattern.project_content_pattern_sv.yml
+++ b/conf/cmi/pathauto.pattern.project_content_pattern_sv.yml
@@ -8,20 +8,20 @@ dependencies:
 id: project_content_pattern_sv
 label: 'Project content pattern (SV)'
 type: 'canonical_entities:node'
-pattern: 'stadsplanering-och-byggande/sok-planer-och-projekt/[node:title]'
+pattern: 'stadsplanering-och-byggande/planer-och-byggnadsprojekt/[node:title]'
 selection_criteria:
-  ebdd871b-9faa-4fe6-a59b-eec4d896b879:
+  8fb70e14-4863-4fc6-990f-e59780496e95:
     id: 'entity_bundle:node'
     negate: false
-    uuid: ebdd871b-9faa-4fe6-a59b-eec4d896b879
+    uuid: 8fb70e14-4863-4fc6-990f-e59780496e95
     context_mapping:
       node: node
     bundles:
       project: project
-  1da9fa60-dbfc-4ac9-836f-d4ada8fbd5ab:
+  7e600edb-5a00-4007-9aaa-6cecd7348091:
     id: language
     negate: false
-    uuid: 1da9fa60-dbfc-4ac9-836f-d4ada8fbd5ab
+    uuid: 7e600edb-5a00-4007-9aaa-6cecd7348091
     context_mapping:
       language: 'node:langcode:language'
     langcodes:


### PR DESCRIPTION
# [UHF-9347](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9347)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updated the path alias pattern for project content to match with the new pattern

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9347`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/admin/config/search/path/update_bulk and select "Content" and "Regenerate URL aliases for all paths". 
* [x] After the url-regeneration go to https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/admin/content?title=&type=project&status=All&langcode=All and select any project and make sure its path alias follows the new pattern: `urban-planning-and-construction/plans-and-building-projects/[node:title]` or `kaupunkisuunnittelu-ja-rakentaminen/suunnitelmat-ja-rakennushankkeet/[node:title]` or `stadsplanering-och-byggande/planer-och-byggnadsprojekt/[node:title]`
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

[UHF-9347]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ