### PR TITLE
UHF-9446: Add update hook that removes district listing paragraphs from the database

### DIFF
--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.install
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.install
@@ -13,3 +13,19 @@ declare(strict_types=1);
 function helfi_kymp_content_update_9001(): void {
   _helfi_kymp_content_create_district_nodes_from_taxonomy_terms();
 }
+
+/**
+ * UHF-9446: Remove all district listing paragraphs.
+ */
+function helfi_kymp_content_update_9002(): void {
+  $storage = \Drupal::entityTypeManager()
+    ->getStorage('paragraph');
+  $entityIds = $storage->getQuery()
+    ->condition('type', 'district_listing')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  foreach ($entityIds as $id) {
+    $storage->load($id)->delete();
+  }
+}


### PR DESCRIPTION
# [UHF-9446](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9446)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This PR removes the district listing paragraphs from the database so that the configuration can be removed afterwards.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9446`
  * `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that there is no more district listing paragraphs on the database by going to shell: `make shell` and running there `drush sql-cli` and in the database shell `select * from paragraphs_item where type='district_listing';`. The query should return empty set.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/806


[UHF-9446]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ