### PR TITLE
Reduce API requests by increasing batch size

### DIFF
--- a/docker/openshift/crons/street-data.sh
+++ b/docker/openshift/crons/street-data.sh
@@ -4,6 +4,6 @@ echo "Start indexing street data from external datasource: $(date)"
 
 while true
 do
-  drush sapi-r street_data && drush sapi-i street_data
+  drush sapi-r street_data && drush sapi-i street_data --batch-size=500
   sleep 86400
 done


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

The street data API seems to become sometimes unresponsive while the data is re-indexed in a cron job. This was notices while looking at the cron pod logs that contain error messages. 

Street data indexing makes a request to `https://kartta.hel.fi/ws/geoserver/avoindata/wfs` for each batch of 50 items. Currently, there are enough items for around 150 batches. The indexing happens every 24 hours.

This pull request increases the batch size so that the items are processed in around 15 batches. This should decrease the load to the street data API.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-street-data-errors`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `bash ./docker/openshift/crons/street-data.sh`
