### PR TITLE
UHF-8650: Preparation for the HDS cookie banner module

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -98,11 +98,22 @@ function hdbt_subtheme_preprocess_node(array &$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_subtheme_preprocess_paragraph__journey_planner(array &$variables): void {
+  // Attach the embedded content cookie compliance library.
   $variables['#attached']['library'][] = 'hdbt/embedded-content-cookie-compliance';
 
-  $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
-  $variables['privacy_policy_url'] = helfi_eu_cookie_compliance_get_privacy_policy_url();
+  // Set the necessary variables for the journey planner.
   $variables['media_service_url'] = 'https://reittiopas.hsl.fi';
-  $variables['media_url'] = 'https://reittiopas.hsl.fi/haku?bikeOnly=1&lang=' . $langcode;
+  $variables['media_url'] = 'https://reittiopas.hsl.fi/haku?bikeOnly=1&lang=' . $variables['language']->getId();
   $variables['media_id'] = 'journey-map';
+
+  // Set the privacy policy URL.
+  if (Drupal::moduleHandler()->moduleExists('hdbt_cookie_banner')) {
+    /** @var \Drupal\hdbt_cookie_banner\Services\CookieSettings $cookie_settings */
+    $cookie_settings = \Drupal::service('hdbt_cookie_banner.cookie_settings');
+    $variables['privacy_policy_url'] = $cookie_settings->getCookieSettingsPageUrl();
+  }
+  // @todo UHF-10862 Remove once the HDBT cookie banner module is in use.
+  elseif (Drupal::moduleHandler()->moduleExists('helfi_eu_cookie_compliance')) {
+    $variables['privacy_policy_url'] = helfi_eu_cookie_compliance_get_privacy_policy_url();
+  }
 }


### PR DESCRIPTION
# [UHF-8650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed the privacy policy URL for the journey planner.

## How to install and test

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8650`
  * `make fresh`
* Run `make drush-cr`
* Check the other necessary installation and testing instructions from https://github.com/City-of-Helsinki/drupal-hdbt/pull/1083

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/832
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1083


[UHF-8650]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ