### PR TITLE
UHF-10239: Added image gallery to district content type

### DIFF
--- a/conf/cmi/field.field.node.district.field_content.yml
+++ b/conf/cmi/field.field.node.district.field_content.yml
@@ -12,7 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.image
-     - paragraphs.paragraphs_type.image_gallery
+    - paragraphs.paragraphs_type.image_gallery
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
     - paragraphs.paragraphs_type.news_list

--- a/conf/cmi/field.field.node.district.field_content.yml
+++ b/conf/cmi/field.field.node.district.field_content.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.image
+     - paragraphs.paragraphs_type.image_gallery
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
     - paragraphs.paragraphs_type.news_list
@@ -47,6 +48,7 @@ settings:
       contact_card_listing: contact_card_listing
       map: map
       project_listing: project_listing
+      image_gallery: image_gallery
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -69,6 +71,9 @@ settings:
         enabled: true
       image:
         weight: 3
+        enabled: true
+      image_gallery:
+        weight: 17
         enabled: true
       list_of_links:
         weight: 4

--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.info.yml
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.info.yml
@@ -7,3 +7,4 @@ package: HELfi
 'interface translation server pattern': modules/custom/helfi_kymp_content/translations/%language.po
 dependencies:
     - search_api:search_api
+    - helfi_platform_config:helfi_paragraphs_image_gallery

--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
@@ -317,6 +317,11 @@ function helfi_kymp_content_helfi_paragraph_types() : array {
           'list_of_plans' => 19,
         ],
       ],
+      'district' => [
+        'field_content' => [
+          'image_gallery' => 17,
+        ],
+      ],
     ],
     'paragraphs_library_item' => [
       'paragraphs_library_item' => [


### PR DESCRIPTION
# [UHF-10239](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10239)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Before checking out have your instance running on latest dev branch by running `make fresh`
* After that:
  * `git checkout UHF-10239 `
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10239`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that image gallery is available in district content type and works as should
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10239]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ