### PR TITLE
UHF-11027: Fix ploughing schedule component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
             "@lint-php",
             "@test-php"
         ],
-        "test-php": "vendor/bin/phpunit -c phpunit.xml.dist",
+        "test-php": "vendor/bin/phpunit -c $PWD/phpunit.xml.dist",
         "lint-php": "vendor/bin/phpcs --standard=Drupal",
         "copy-commit-message-script": "make copy-commit-message-script",
         "post-install-cmd": [

--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.services.yml
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.services.yml
@@ -1,4 +1,8 @@
 services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
   logger.channel.helfi_kymp_content:
     parent: logger.channel_base
     arguments:
@@ -9,3 +13,5 @@ services:
     arguments: ['@logger.channel.helfi_kymp_content']
     tags:
       - { name: event_subscriber }
+
+  Drupal\helfi_kymp_content\StreetDataService: ~

--- a/public/modules/custom/helfi_kymp_content/src/Plugin/DataType/StreetData.php
+++ b/public/modules/custom/helfi_kymp_content/src/Plugin/DataType/StreetData.php
@@ -27,7 +27,7 @@ class StreetData extends Map {
   public static function propertyDefinitions(): array {
     $properties = [];
 
-    $properties['id'] = DataDefinition::create('integer')
+    $properties['id'] = DataDefinition::create('string')
       ->setLabel('id')
       ->setRequired(TRUE);
 

--- a/public/modules/custom/helfi_kymp_content/src/Plugin/DataType/StreetData.php
+++ b/public/modules/custom/helfi_kymp_content/src/Plugin/DataType/StreetData.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_kymp_content\Plugin\DataType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\Attribute\DataType;
 use Drupal\Core\TypedData\DataDefinition;
 use Drupal\Core\TypedData\Plugin\DataType\Map;
+use Drupal\helfi_kymp_content\TypedData\StreetDataDefinition;
 
 /**
  * Street data type.
- *
- * @DataType(
- *   id = "street_data",
- *   label = @Translation("Street data"),
- *   constraints = {},
- *   definition_class = "\Drupal\helfi_kymp_content\TypedData\StreetDataDefinition"
- * )
  */
+#[DataType(
+  id: "street_data",
+  label: new TranslatableMarkup("Street data"),
+  definition_class: StreetDataDefinition::class,
+  constraints: [],
+)]
 class StreetData extends Map {
 
   /**

--- a/public/modules/custom/helfi_kymp_content/src/Plugin/search_api/datasource/HelfiStreetDataSource.php
+++ b/public/modules/custom/helfi_kymp_content/src/Plugin/search_api/datasource/HelfiStreetDataSource.php
@@ -6,13 +6,10 @@ namespace Drupal\helfi_kymp_content\Plugin\search_api\datasource;
 
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\TypedData\ComplexDataInterface;
-use Drupal\Core\TypedData\TypedDataTrait;
 use Drupal\helfi_kymp_content\Plugin\DataType\StreetData;
+use Drupal\helfi_kymp_content\StreetDataService;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Datasource\DatasourcePluginBase;
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\GuzzleException;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,31 +23,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class HelfiStreetDataSource extends DatasourcePluginBase implements DatasourceInterface {
 
-  use TypedDataTrait;
-
-  public const API_URL = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs';
-
   /**
    * The client.
-   *
-   * @var \GuzzleHttp\ClientInterface
    */
-  protected ClientInterface $client;
-
-  /**
-   * The logger.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected LoggerInterface $logger;
+  protected StreetDataService $client;
 
   /**
    * {@inheritDoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
-    $instance->client = $container->get('http_client');
-    $instance->logger = $container->get('logger.channel.helfi_kymp_content');
+    $instance->client = $container->get(StreetDataService::class);
     return $instance;
   }
 
@@ -73,74 +56,13 @@ class HelfiStreetDataSource extends DatasourcePluginBase implements DatasourceIn
    * {@inheritdoc}
    */
   public function loadMultiple(array $ids): array {
-    $query = http_build_query([
-      'request' => 'GetFeature',
-      'service' => 'WFS',
-      'version' => '1.1.0',
-      'typeName' => 'avoindata:YLRE_Katualue_alue',
-      'propertyname' => 'avoindata:kadun_nimi,avoindata:kayttotarkoitus,avoindata:yllapitoluokka,avoindata:pituus',
-    ]);
-    $uri = sprintf('%s?%s', self::API_URL, $query);
+    $streetData = $this->client->getStreetData();
 
-    try {
-      $content = $this->client->request('GET', $uri);
-      $xmlResult = $content->getBody()->getContents();
-      if (!$xmlResult) {
-        return [];
-      }
-    }
-    catch (GuzzleException $e) {
-      $this->logger->error("Errors while fetching street data from kartta.hel.fi: {$e->getMessage()}");
-      return [];
+    if ($ids) {
+      return array_intersect_key($streetData, array_flip($ids));
     }
 
-    libxml_use_internal_errors(TRUE);
-    $doc = new \DOMDocument(encoding: 'UTF-8');
-    $doc->loadXML($xmlResult);
-    $errors = libxml_get_errors();
-
-    if ($errors) {
-      $this->logger->error('Errors while parsing street data xml string.');
-      return [];
-    }
-
-    $data = [];
-    foreach ($doc->firstChild->firstChild->childNodes->getIterator() as $street_data) {
-      $id = $street_data->getAttribute('gml:id');
-
-      if (!$id || $ids && !in_array($id, $ids)) {
-        continue;
-      }
-
-      $single_street = [
-        'id' => $id,
-      ];
-
-      foreach ($street_data->childNodes->getIterator() as $field) {
-        switch ($field->nodeName) {
-          case 'avoindata:kadun_nimi':
-            $single_street['street_name'] = $field->nodeValue;
-            break;
-
-          case 'avoindata:pituus':
-            $single_street['length'] = $field->nodeValue;
-            break;
-
-          case 'avoindata:yllapitoluokka':
-            // Turn field value from III or II to 3 or 2 etc.
-            $single_street['maintenance_class'] = strlen($field->nodeValue);
-            break;
-        }
-      }
-
-      $street_data_definition = $this->getTypedDataManager()->createDataDefinition('street_data');
-      /** @var \Drupal\Core\TypedData\ComplexDataInterface $street_data */
-      $street_data = $this->getTypedDataManager()->create($street_data_definition);
-      $street_data->setValue($single_street);
-      $data[$id] = $street_data;
-    }
-
-    return $data;
+    return $streetData;
   }
 
   /**

--- a/public/modules/custom/helfi_kymp_content/src/Plugin/search_api/datasource/HelfiStreetDataSource.php
+++ b/public/modules/custom/helfi_kymp_content/src/Plugin/search_api/datasource/HelfiStreetDataSource.php
@@ -6,8 +6,8 @@ namespace Drupal\helfi_kymp_content\Plugin\search_api\datasource;
 
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\TypedData\ComplexDataInterface;
-use Drupal\Core\TypedData\DataDefinition;
 use Drupal\Core\TypedData\TypedDataTrait;
+use Drupal\helfi_kymp_content\Plugin\DataType\StreetData;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Datasource\DatasourcePluginBase;
 use GuzzleHttp\ClientInterface;
@@ -155,24 +155,7 @@ class HelfiStreetDataSource extends DatasourcePluginBase implements DatasourceIn
    * {@inheritdoc}
    */
   public function getPropertyDefinitions(): array {
-    $property_definition = [];
-
-    $property_definition['id'] = DataDefinition::create('integer')
-      ->setLabel('id')
-      ->setRequired(TRUE);
-    $property_definition['street_name'] = DataDefinition::create('string')
-      ->setLabel('Street name')
-      ->addConstraint('Range', ['min' => 0, 'max' => 255])
-      ->setRequired(TRUE);
-    $property_definition['length'] = DataDefinition::create('integer')
-      ->setLabel('Length')
-      ->setRequired(TRUE);
-    $property_definition['maintenance_class'] = DataDefinition::create('integer')
-      ->setLabel('Maintenance class')
-      ->addConstraint('Range', ['min' => 0, 'max' => 5])
-      ->setRequired(TRUE);
-
-    return $property_definition;
+    return StreetData::propertyDefinitions();
   }
 
 }

--- a/public/modules/custom/helfi_kymp_content/src/StreetDataService.php
+++ b/public/modules/custom/helfi_kymp_content/src/StreetDataService.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_kymp_content;
+
+use Drupal\Core\TypedData\TypedDataManagerInterface;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Service for fetching street data from kartta.hel.fi.
+ */
+final readonly class StreetDataService {
+
+  public const API_URL = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs';
+
+  /**
+   * Constructs a new StreetDataService instance.
+   */
+  public function __construct(
+    protected ClientInterface $client,
+    protected TypedDataManagerInterface $typedDataManager,
+    #[Autowire(service: 'logger.channel.helfi_kymp_content')]
+    protected LoggerInterface $logger,
+  ) {
+  }
+
+  /**
+   * Gets street data.
+   *
+   * @return \Drupal\helfi_kymp_content\Plugin\DataType\StreetData[]
+   *   Street data.
+   */
+  public function getStreetData(): array {
+    $query = http_build_query([
+      'request' => 'GetFeature',
+      'service' => 'WFS',
+      'version' => '1.1.0',
+      'typeName' => 'avoindata:YLRE_Katualue_alue',
+      'propertyname' => 'avoindata:kadun_nimi,avoindata:yllapitoluokka,avoindata:pituus',
+    ]);
+    $uri = sprintf('%s?%s', self::API_URL, $query);
+
+    try {
+      $content = $this->client->request('GET', $uri);
+      $xmlResult = $content->getBody()->getContents();
+      if (!$xmlResult) {
+        return [];
+      }
+    }
+    catch (GuzzleException $e) {
+      $this->logger->error("Errors while fetching street data from kartta.hel.fi: {$e->getMessage()}");
+      return [];
+    }
+
+    libxml_use_internal_errors(TRUE);
+    $doc = new \DOMDocument(encoding: 'UTF-8');
+    $doc->loadXML($xmlResult);
+    $errors = libxml_get_errors();
+
+    if ($errors) {
+      $this->logger->error('Errors while parsing street data xml string.');
+      return [];
+    }
+
+    $data = [];
+    foreach ($doc->firstChild->firstChild->childNodes->getIterator() as $street_data) {
+      $id = $street_data->getAttribute('gml:id');
+      if (!$id) {
+        continue;
+      }
+
+      $single_street = [
+        'id' => $id,
+      ];
+
+      foreach ($street_data->childNodes->getIterator() as $field) {
+        switch ($field->nodeName) {
+          case 'avoindata:kadun_nimi':
+            $single_street['street_name'] = $field->nodeValue;
+            break;
+
+          case 'avoindata:pituus':
+            $single_street['length'] = $field->nodeValue;
+            break;
+
+          case 'avoindata:yllapitoluokka':
+            // Turn field value from III or II to 3 or 2 etc.
+            $single_street['maintenance_class'] = strlen($field->nodeValue);
+            break;
+        }
+      }
+
+      $street_data_definition = $this->typedDataManager->createDataDefinition('street_data');
+      /** @var \Drupal\Core\TypedData\ComplexDataInterface $street_data */
+      $street_data = $this->typedDataManager->create($street_data_definition);
+      $street_data->setValue($single_street);
+      $data[$id] = $street_data;
+    }
+
+    return $data;
+  }
+
+}

--- a/public/modules/custom/helfi_kymp_content/src/TypedData/StreetDataDefinition.php
+++ b/public/modules/custom/helfi_kymp_content/src/TypedData/StreetDataDefinition.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\helfi_kymp_content\TypedData;
 
 use Drupal\Core\TypedData\ComplexDataDefinitionBase;
-use Drupal\Core\TypedData\DataDefinition;
+use Drupal\helfi_kymp_content\Plugin\DataType\StreetData;
 
 /**
  * The street data definition.
@@ -15,22 +15,9 @@ class StreetDataDefinition extends ComplexDataDefinitionBase {
   /**
    * {@inheritDoc}
    */
-  public function getPropertyDefinitions() {
+  public function getPropertyDefinitions(): array {
     if (!isset($this->propertyDefinitions)) {
-      $this->propertyDefinitions['id'] = DataDefinition::create('integer')
-        ->setLabel('id')
-        ->setRequired(TRUE);
-      $this->propertyDefinitions['street_name'] = DataDefinition::create('string')
-        ->setLabel('Street name')
-        ->addConstraint('Range', ['min' => 0, 'max' => 255])
-        ->setRequired(TRUE);
-      $this->propertyDefinitions['length'] = DataDefinition::create('integer')
-        ->setLabel('Length')
-        ->setRequired(TRUE);
-      $this->propertyDefinitions['maintenance_class'] = DataDefinition::create('integer')
-        ->setLabel('Maintenance class')
-        ->addConstraint('Range', ['min' => 0, 'max' => 5])
-        ->setRequired(TRUE);
+      $this->propertyDefinitions = StreetData::propertyDefinitions();
     }
     return $this->propertyDefinitions;
   }

--- a/public/modules/custom/helfi_kymp_content/tests/fixtures/street_data.xml
+++ b/public/modules/custom/helfi_kymp_content/tests/fixtures/street_data.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:avoindata="https://www.hel.fi/avoindata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" numberOfFeatures="7717" timeStamp="2024-11-28T11:58:56.213+02:00" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd https://www.hel.fi/avoindata https://kartta.hel.fi/ws/geoserver/avoindata/wfs?service=WFS&amp;version=1.1.0&amp;request=DescribeFeatureType&amp;typeName=avoindata%3AYLRE_Katualue_alue">
+  <gml:featureMembers>
+    <avoindata:YLRE_Katualue_alue gml:id="YLRE_Katualue_alue.228">
+      <avoindata:kadun_nimi>Suovakuja</avoindata:kadun_nimi>
+      <avoindata:kayttotarkoitus>Asuntokatu</avoindata:kayttotarkoitus>
+      <avoindata:yllapitoluokka>I</avoindata:yllapitoluokka>
+      <avoindata:pituus>139.5</avoindata:pituus>
+    </avoindata:YLRE_Katualue_alue>
+    <avoindata:YLRE_Katualue_alue gml:id="YLRE_Katualue_alue.797">
+      <avoindata:kadun_nimi>Rauhankatu</avoindata:kadun_nimi>
+      <avoindata:kayttotarkoitus>Asuntokatu</avoindata:kayttotarkoitus>
+      <avoindata:yllapitoluokka>II</avoindata:yllapitoluokka>
+      <avoindata:pituus>130.3</avoindata:pituus>
+    </avoindata:YLRE_Katualue_alue>
+    <avoindata:YLRE_Katualue_alue gml:id="YLRE_Katualue_alue.809">
+      <avoindata:kadun_nimi>Kruunuhaankatu</avoindata:kadun_nimi>
+      <avoindata:kayttotarkoitus>Asuntokatu</avoindata:kayttotarkoitus>
+      <avoindata:yllapitoluokka>III</avoindata:yllapitoluokka>
+      <avoindata:pituus>72.4</avoindata:pituus>
+    </avoindata:YLRE_Katualue_alue>
+    <avoindata:YLRE_Katualue_alue gml:id="YLRE_Katualue_alue.448">
+      <avoindata:kadun_nimi>Sammonkatu</avoindata:kadun_nimi>
+      <avoindata:kayttotarkoitus>Asuntokatu</avoindata:kayttotarkoitus>
+      <avoindata:yllapitoluokka>III</avoindata:yllapitoluokka>
+      <avoindata:pituus>75.3</avoindata:pituus>
+    </avoindata:YLRE_Katualue_alue>
+  </gml:featureMembers>
+</wfs:FeatureCollection>

--- a/public/modules/custom/helfi_kymp_content/tests/src/Kernel/Plugin/StreetDataSourceTest.php
+++ b/public/modules/custom/helfi_kymp_content/tests/src/Kernel/Plugin/StreetDataSourceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_kymp_content\Kernel\Plugin;
+
+use Drupal\helfi_kymp_content\Plugin\search_api\datasource\HelfiStreetDataSource;
+use Drupal\helfi_kymp_content\StreetDataService;
+use Drupal\KernelTests\KernelTestBase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Tests helfi_street_data_source plugin.
+ */
+class StreetDataSourceTest extends KernelTestBase {
+
+  use ProphecyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'search_api',
+    'helfi_kymp_content',
+  ];
+
+  /**
+   * Tests street data service.
+   */
+  public function testStreetDataSource(): void {
+    $items = [
+      'id1' => 'item1',
+      'id2' => 'item2',
+    ];
+
+    $streetData = $this->prophesize(StreetDataService::class);
+
+    $streetData->getStreetData()
+      ->shouldBeCalled()
+      ->willReturn($items);
+
+    $this->container->set(StreetDataService::class, $streetData->reveal());
+
+    /** @var \Drupal\Component\Plugin\PluginManagerInterface $pluginManager */
+    $pluginManager = $this->container->get('plugin.manager.search_api.datasource');
+    $sut = $pluginManager->createInstance('helfi_street_data_source', []);
+
+    $this->assertInstanceOf(HelfiStreetDataSource::class, $sut);
+    $this->assertEquals('item1', $sut->load('id1'));
+    $this->assertEquals(NULL, $sut->load('does not exist'));
+    $this->assertEquals(['id1' => 'item1'], $sut->loadMultiple(['id1']));
+    $this->assertEquals($items, $sut->loadMultiple([]));
+  }
+
+}

--- a/public/modules/custom/helfi_kymp_content/tests/src/Kernel/StreetDataTest.php
+++ b/public/modules/custom/helfi_kymp_content/tests/src/Kernel/StreetDataTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_kymp_content\Kernel;
+
+use Drupal\helfi_kymp_content\Plugin\DataType\StreetData;
+use Drupal\helfi_kymp_content\StreetDataService;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Tests street data service.
+ */
+class StreetDataTest extends KernelTestBase {
+
+  use ApiTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_kymp_content',
+  ];
+
+  /**
+   * Tests street data service.
+   */
+  public function testStreetDataService(): void {
+    $this->setupMockHttpClient([
+      new RequestException('test', new Request('GET', 'test')),
+      new Response(body: 'invalid-xml'),
+      new Response(body: file_get_contents(__DIR__ . '/../../fixtures/street_data.xml')),
+    ]);
+
+    $sut = $this->container->get(StreetDataService::class);
+
+    // RequestException response.
+    $data = $sut->getStreetData();
+    $this->assertEmpty($data);
+
+    // Invalid XML response.
+    $data = $sut->getStreetData();
+    $this->assertEmpty($data);
+
+    // Fixture response.
+    $data = $sut->getStreetData();
+    $this->assertNotEmpty($data);
+
+    foreach ($data as $id => $street) {
+      $this->assertInstanceOf(StreetData::class, $street);
+      $this->assertEquals($id, $street->get('id')->getValue());
+    }
+
+    $street = $data['YLRE_Katualue_alue.809'];
+    $this->assertNotEmpty($street);
+    $this->assertEquals('Kruunuhaankatu', $street->get('street_name')->getValue());
+    $this->assertEquals("72.4", $street->get('length')->getValue());
+    $this->assertEquals(3, $street->get('maintenance_class')->getValue());
+  }
+
+}


### PR DESCRIPTION
# [UHF-11027](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11027)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->
Kartta api no longer returns `<avoindata:katualue_id>` elements in the [response](https://kartta.hel.fi/ws/geoserver/avoindata/wfs?request=GetFeature&service=WFS&version=1.1.0&typeName=avoindata%3AYLRE_Katualue_alue&propertyname=avoindata%3Akadun_nimi%2Cavoindata%3Akayttotarkoitus%2Cavoindata%3Ayllapitoluokka%2Cavoindata%3Apituus). These were used as the document ids. I changed it to use `gml:id` attribute in the `<avoindata:YLRE_Katualue_alue>` node instead.

This also adds tests to the feature.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11027`
  * `make fresh`
  * `Run drush sapi-rt street_data; drush sapi-c street_data; drush sapi-i street_data --batch-size=500`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that this feature works: https://helfi-kymp.docker.so/en/urban-environment-and-traffic/general-maintenance/street-maintenance/winter-street-maintenance
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR


[UHF-11027]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ