### PR TITLE
UHF-10338: disable the custom migration module

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -51,7 +51,6 @@ module:
   helfi_etusivu_entities: 0
   helfi_image_styles: 0
   helfi_kymp_content: 0
-  helfi_kymp_migrations: 0
   helfi_kymp_plans: 0
   helfi_media: 0
   helfi_media_chart: 0


### PR DESCRIPTION
The module was used to run migrations once. Should have been disabled and removed a long time ago