### PR TITLE
UHF-11514: Translation fixes

### DIFF
--- a/conf/cmi/language/fi/core.base_field_override.node.district.status.yml
+++ b/conf/cmi/language/fi/core.base_field_override.node.district.status.yml
@@ -1,0 +1,1 @@
+label: Julkaistu


### PR DESCRIPTION
# [UHF-11514](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11514)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add missing Finnish translation configuration for the district published field

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11514`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
