### PR TITLE
UHF-11656: Added number highlights paragraph to district and project pages

### DIFF
--- a/conf/cmi/field.field.node.district.field_content.yml
+++ b/conf/cmi/field.field.node.district.field_content.yml
@@ -16,6 +16,7 @@ dependencies:
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
     - paragraphs.paragraphs_type.news_list
+    - paragraphs.paragraphs_type.number_highlights
     - paragraphs.paragraphs_type.project_listing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
@@ -49,6 +50,7 @@ settings:
       map: map
       project_listing: project_listing
       image_gallery: image_gallery
+      number_highlights: number_highlights
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -83,6 +85,9 @@ settings:
         enabled: true
       news_list:
         weight: 15
+        enabled: true
+      number_highlights:
+        weight: 18
         enabled: true
       project_listing:
         weight: 16

--- a/conf/cmi/field.field.node.district.field_lower_content.yml
+++ b/conf/cmi/field.field.node.district.field_lower_content.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_lower_content
     - node.type.district
     - paragraphs.paragraphs_type.list_of_links
+    - paragraphs.paragraphs_type.number_highlights
   module:
     - entity_reference_revisions
 id: node.district.field_lower_content
@@ -23,6 +24,7 @@ settings:
   handler_settings:
     target_bundles:
       list_of_links: list_of_links
+      number_highlights: number_highlights
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -91,6 +93,9 @@ settings:
       news_list:
         weight: -54
         enabled: false
+      number_highlights:
+        weight: 17
+        enabled: true
       phasing:
         weight: -43
         enabled: false

--- a/conf/cmi/field.field.node.project.field_content.yml
+++ b/conf/cmi/field.field.node.project.field_content.yml
@@ -14,6 +14,7 @@ dependencies:
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
+    - paragraphs.paragraphs_type.number_highlights
     - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
@@ -45,6 +46,7 @@ settings:
       contact_card_listing: contact_card_listing
       map: map
       phasing: phasing
+      number_highlights: number_highlights
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -73,6 +75,9 @@ settings:
         enabled: true
       map:
         weight: 9
+        enabled: true
+      number_highlights:
+        weight: 11
         enabled: true
       phasing:
         weight: 7

--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.info.yml
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.info.yml
@@ -8,3 +8,4 @@ package: HELfi
 dependencies:
     - search_api:search_api
     - helfi_platform_config:helfi_paragraphs_image_gallery
+    - helfi_platform_config:helfi_paragraphs_number_highlights

--- a/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
+++ b/public/modules/custom/helfi_kymp_content/helfi_kymp_content.module
@@ -320,6 +320,15 @@ function helfi_kymp_content_helfi_paragraph_types() : array {
       'district' => [
         'field_content' => [
           'image_gallery' => 17,
+          'number_highlights' => 18,
+        ],
+        'field_lower_content' => [
+          'number_highlights' => 17,
+        ],
+      ],
+      'project' => [
+        'field_content' => [
+          'number_highlights' => 11,
         ],
       ],
     ],


### PR DESCRIPTION
# [UHF-11656](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11656)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added number highlights to district page upper and lower content areas and content area for project

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11656`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See platform config for instructions
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/329
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/941
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1246
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/1079
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/898


[UHF-11656]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ