### PR TITLE
UHF-5038: Made journey planner title required

### DIFF
--- a/conf/cmi/field.field.paragraph.journey_planner.field_title.yml
+++ b/conf/cmi/field.field.paragraph.journey_planner.field_title.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: journey_planner
 label: Title
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
# [UHF-5038](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5038)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed journey planner title to be required

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-5038 `
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add a journey planner to a basic page and make sure the title is required 
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1019
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1306
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/1122


[UHF-5038]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-5038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ