### PR TITLE
UHF-10862: Remove call to helfi_eu_cookie_compliance_get_policy_url function

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -111,8 +111,4 @@ function hdbt_subtheme_preprocess_paragraph__journey_planner(array &$variables):
     $cookie_settings = Drupal::service('hdbt_cookie_banner.cookie_settings');
     $variables['privacy_policy_url'] = $cookie_settings->getCookieSettingsPageUrl();
   }
-  // @todo UHF-10862 Remove once the HDBT cookie banner module is in use.
-  elseif (Drupal::moduleHandler()->moduleExists('helfi_eu_cookie_compliance')) {
-    $variables['privacy_policy_url'] = helfi_eu_cookie_compliance_get_privacy_policy_url();
-  }
 }


### PR DESCRIPTION
# [UHF-10862](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10862)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove call to helfi_eu_cookie_compliance_get_policy_url function

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10862`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure the https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/pyoraily/pyorareitit pages HSL embedded block still works correctly when cookies are approved and that it is not visible when cookies are not approved.
* [ ] Check that code follows our standards.


[UHF-10862]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ