### PR TITLE
UHF-13100: Updated district and project indexes to use the new Main image processor

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4356,16 +4356,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "6.16.55",
+            "version": "6.16.59",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "da7c7ba04beb379562882db4f2d4ae6a60a65500"
+                "reference": "514a645d540002f360509534bb7441318969aa9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/da7c7ba04beb379562882db4f2d4ae6a60a65500",
-                "reference": "da7c7ba04beb379562882db4f2d4ae6a60a65500",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/514a645d540002f360509534bb7441318969aa9a",
+                "reference": "514a645d540002f360509534bb7441318969aa9a",
                 "shasum": ""
             },
             "require": {
@@ -4384,10 +4384,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/6.16.55",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/6.16.59",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2026-03-23T14:28:27+00:00"
+            "time": "2026-04-01T10:53:42+00:00"
         },
         {
             "name": "drupal/hdbt_admin",
@@ -4722,16 +4722,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "5.1.27",
+            "version": "5.1.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "b4468697b77584a7e1708b863f156e087226a952"
+                "reference": "b31075e2deb49ff6ada7248570b976f1ae795817"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/b4468697b77584a7e1708b863f156e087226a952",
-                "reference": "b4468697b77584a7e1708b863f156e087226a952",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/b31075e2deb49ff6ada7248570b976f1ae795817",
+                "reference": "b31075e2deb49ff6ada7248570b976f1ae795817",
                 "shasum": ""
             },
             "require": {
@@ -4846,10 +4846,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/5.1.27",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/5.1.33",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2026-03-24T07:55:28+00:00"
+            "time": "2026-04-03T04:32:46+00:00"
         },
         {
             "name": "drupal/helfi_proxy",

--- a/conf/cmi/search_api.index.districts.yml
+++ b/conf/cmi/search_api.index.districts.yml
@@ -9,7 +9,9 @@ dependencies:
     - field.storage.node.field_subdistricts
     - search_api.server.default
   module:
+    - helfi_platform_config
     - helfi_react_search
+    - helfi_recommendations
     - media
     - node
 id: districts
@@ -25,11 +27,6 @@ field_settings:
     dependencies:
       module:
         - node
-  district_image_absolute_url:
-    label: 'District image absolute URL'
-    datasource_id: 'entity:node'
-    property_path: district_image_absolute_url
-    type: string
   field_district_image_alt:
     label: 'District image alt'
     datasource_id: 'entity:node'
@@ -92,6 +89,13 @@ field_settings:
         - field.storage.node.field_subdistricts
       module:
         - node
+  main_image_url:
+    label: 'Main image: URL'
+    datasource_id: 'entity:node'
+    property_path: main_image_url
+    type: string
+    configuration:
+      field_name: field_district_image
   nid:
     label: Nid
     datasource_id: 'entity:node'
@@ -138,7 +142,7 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
-  district_image_absolute_url: {  }
+  custom_value: {  }
   entity_status: {  }
   entity_type: {  }
   ignorecase:
@@ -152,10 +156,12 @@ processor_settings:
       - field_district_subdistricts_title
       - title
   language_with_fallback: {  }
+  main_image_url: {  }
   project_execution_schedule: {  }
-  project_image_absolute_url: {  }
   project_plan_schedule: {  }
   rendered_item: {  }
+  scored_reference: {  }
+  scored_reference_parent: {  }
   tokenizer:
     weights:
       preprocess_index: -6
@@ -172,6 +178,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: false
   track_changes_in_references: true
 server: default

--- a/conf/cmi/search_api.index.districts.yml
+++ b/conf/cmi/search_api.index.districts.yml
@@ -96,6 +96,17 @@ field_settings:
     type: string
     configuration:
       field_name: field_district_image
+      image_styles:
+        - { id: '1.5_304w_203h', breakpoint: '1248' }
+        - { id: '1.5_294w_196h', breakpoint: '992' }
+        - { id: '1.5_220w_147h', breakpoint: '768' }
+        - { id: '1.5_176w_118h', breakpoint: '576' }
+        - { id: '1.5_511w_341h', breakpoint: '320' }
+        - { id: '1.5_608w_406w_LQ', breakpoint: '1248_2x' }
+        - { id: '1.5_588w_392h_LQ', breakpoint: '992_2x' }
+        - { id: '1.5_440w_294h_LQ', breakpoint: '768_2x' }
+        - { id: '1.5_352w_236h_LQ', breakpoint: '576_2x' }
+        - { id: '1.5_1022w_682h_LQ', breakpoint: '320_2x' }
   nid:
     label: Nid
     datasource_id: 'entity:node'

--- a/conf/cmi/search_api.index.projects.yml
+++ b/conf/cmi/search_api.index.projects.yml
@@ -13,7 +13,9 @@ dependencies:
     - field.storage.node.field_project_type
     - search_api.server.default
   module:
+    - helfi_platform_config
     - helfi_react_search
+    - helfi_recommendations
     - media
     - node
     - taxonomy
@@ -130,6 +132,13 @@ field_settings:
         - field.storage.node.field_project_type
       module:
         - taxonomy
+  main_image_url:
+    label: 'Main image: URL'
+    datasource_id: 'entity:node'
+    property_path: main_image_url
+    type: string
+    configuration:
+      field_name: field_project_image
   nid:
     label: Nid
     datasource_id: 'entity:node'
@@ -142,11 +151,6 @@ field_settings:
     label: 'Project execution schedule'
     datasource_id: 'entity:node'
     property_path: project_execution_schedule
-    type: string
-  project_image_absolute_url:
-    label: 'Project image absolute URL'
-    datasource_id: 'entity:node'
-    property_path: project_image_absolute_url
     type: string
   project_plan_schedule:
     label: 'Project plan schedule'
@@ -191,7 +195,7 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
-  district_image_absolute_url: {  }
+  custom_value: {  }
   entity_status: {  }
   entity_type: {  }
   ignorecase:
@@ -208,10 +212,12 @@ processor_settings:
       - field_project_type_name
       - title
   language_with_fallback: {  }
+  main_image_url: {  }
   project_execution_schedule: {  }
-  project_image_absolute_url: {  }
   project_plan_schedule: {  }
   rendered_item: {  }
+  scored_reference: {  }
+  scored_reference_parent: {  }
   tokenizer:
     weights:
       preprocess_index: -6
@@ -228,6 +234,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: false
   track_changes_in_references: true
 server: default

--- a/conf/cmi/search_api.index.projects.yml
+++ b/conf/cmi/search_api.index.projects.yml
@@ -139,6 +139,17 @@ field_settings:
     type: string
     configuration:
       field_name: field_project_image
+      image_styles:
+        - { id: '1.5_304w_203h', breakpoint: '1248' }
+        - { id: '1.5_294w_196h', breakpoint: '992' }
+        - { id: '1.5_220w_147h', breakpoint: '768' }
+        - { id: '1.5_176w_118h', breakpoint: '576' }
+        - { id: '1.5_511w_341h', breakpoint: '320' }
+        - { id: '1.5_608w_406w_LQ', breakpoint: '1248_2x' }
+        - { id: '1.5_588w_392h_LQ', breakpoint: '992_2x' }
+        - { id: '1.5_440w_294h_LQ', breakpoint: '768_2x' }
+        - { id: '1.5_352w_236h_LQ', breakpoint: '576_2x' }
+        - { id: '1.5_1022w_682h_LQ', breakpoint: '320_2x' }
   nid:
     label: Nid
     datasource_id: 'entity:node'


### PR DESCRIPTION
## How to install
- `git checkout UHF-13019`
- `composer require drupal/helfi_platform_config:dev-UHF-13019`
- `drush deploy`

## How to test

* [ ] Re-index district and projects indexes
* [ ] Make sure new `main_image_url` field is available in both indexes