### PR TITLE
UHF-12774: Add 24 hours to valid_to timestamp

### DIFF
--- a/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
+++ b/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
@@ -213,21 +213,30 @@ XML;
     $properties = $feature['properties'] ?? [];
     $geometry = $feature['geometry'] ?? [];
 
-    $item = [
-      'id' => $featureId,
-      'address' => $properties['osoite'] ?? '',
-      'reason' => $properties['merkinSyy']['value'] ?? '',
-      'valid_from' => $this->dateToTimestamp($properties['voimassaoloAlku'] ?? NULL),
-      'valid_to' => $this->dateToTimestamp($properties['voimassaoloLoppu'] ?? NULL),
-      'time_range' => $properties['kello'] ?? '',
-      'created_at' => $this->dateTimeToTimestamp($properties['luontipvm'] ?? NULL),
-      'updated_at' => $this->dateTimeToTimestamp($properties['paivityspvm'] ?? NULL),
-      'address_info' => $properties['osoitteenlisatieto'] ?? '',
-      'sign_type' => $properties['merkinLaatu']['value'] ?? '',
-      'additional_text' => $properties['lisakilvenTeksti'] ?? '',
-      'notes' => $properties['huomautukset'] ?? '',
-      'phone' => $properties['puhelinnumero'] ?? '',
-    ];
+    if (empty($properties['voimassaoloAlku']) || empty($properties['voimassaoloLoppu'])) {}
+
+    try {
+      $item = [
+        'id' => $featureId,
+        'address' => $properties['osoite'] ?? '',
+        'reason' => $properties['merkinSyy']['value'] ?? '',
+        'valid_from' => $this->dateToTimestamp($properties['voimassaoloAlku'] ?? NULL),
+        // We only get date string from mobilenote. We
+        // add 25 hours to get the end timestamp.
+        'valid_to' => $this->dateToTimestamp($properties['voimassaoloLoppu'] ?? NULL) + 86400 + 3600,
+        'time_range' => $properties['kello'] ?? '',
+        'created_at' => $this->dateTimeToTimestamp($properties['luontipvm'] ?? NULL),
+        'updated_at' => $this->dateTimeToTimestamp($properties['paivityspvm'] ?? NULL),
+        'address_info' => $properties['osoitteenlisatieto'] ?? '',
+        'sign_type' => $properties['merkinLaatu']['value'] ?? '',
+        'additional_text' => $properties['lisakilvenTeksti'] ?? '',
+        'notes' => $properties['huomautukset'] ?? '',
+        'phone' => $properties['puhelinnumero'] ?? '',
+      ];
+    }
+    catch (\DateMalformedStringException $e) {
+      throw new \InvalidArgumentException("MobileNote: Invalid date", previous: $e);
+    }
 
     // Convert geometry to GeoJSON object.
     if (!empty($geometry['coordinates'])) {
@@ -252,17 +261,15 @@ XML;
    *
    * @return int|null
    *   The timestamp or NULL.
+   *
+   * @throws \DateMalformedStringException
    */
   protected function dateToTimestamp(?string $dateString): ?int {
     if (empty($dateString)) {
-      return NULL;
+      throw new \DateMalformedStringException('Empty date string');
     }
-    try {
-      return (new \DateTime($dateString))->getTimestamp();
-    }
-    catch (\DateMalformedStringException) {
-      return NULL;
-    }
+
+    return (new \DateTime($dateString))->getTimestamp();
   }
 
   /**

--- a/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
+++ b/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
@@ -220,8 +220,8 @@ XML;
         'reason' => $properties['merkinSyy']['value'] ?? '',
         'valid_from' => $this->dateToTimestamp($properties['voimassaoloAlku'] ?? NULL),
         // We only get date string from mobilenote. We
-        // add 25 hours to get the end timestamp.
-        'valid_to' => $this->dateToTimestamp($properties['voimassaoloLoppu'] ?? NULL) + 86400 + 3600,
+        // add 24 hours to get the end timestamp.
+        'valid_to' => $this->dateToTimestamp($properties['voimassaoloLoppu'] ?? NULL) + 86400,
         'time_range' => $properties['kello'] ?? '',
         'created_at' => $this->dateTimeToTimestamp($properties['luontipvm'] ?? NULL),
         'updated_at' => $this->dateTimeToTimestamp($properties['paivityspvm'] ?? NULL),
@@ -232,7 +232,7 @@ XML;
         'phone' => $properties['puhelinnumero'] ?? '',
       ];
     }
-    catch (\DateMalformedStringException $e) {
+    catch (\DateException $e) {
       throw new \InvalidArgumentException("MobileNote: Invalid date", previous: $e);
     }
 
@@ -260,14 +260,14 @@ XML;
    * @return int|null
    *   The timestamp or NULL.
    *
-   * @throws \DateMalformedStringException
+   * @throws \DateException
    */
   protected function dateToTimestamp(?string $dateString): ?int {
     if (empty($dateString)) {
       throw new \DateMalformedStringException('Empty date string');
     }
 
-    return (new \DateTime($dateString))->getTimestamp();
+    return (new \DateTime($dateString, new \DateTimeZone('Europe/Helsinki')))->getTimestamp();
   }
 
   /**
@@ -284,9 +284,9 @@ XML;
       return NULL;
     }
     try {
-      return (new \DateTime($dateTimeString))->getTimestamp();
+      return (new \DateTime($dateTimeString, new \DateTimeZone('Europe/Helsinki')))->getTimestamp();
     }
-    catch (\DateMalformedStringException) {
+    catch (\DateException) {
       return NULL;
     }
   }

--- a/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
+++ b/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
@@ -213,8 +213,6 @@ XML;
     $properties = $feature['properties'] ?? [];
     $geometry = $feature['geometry'] ?? [];
 
-    if (empty($properties['voimassaoloAlku']) || empty($properties['voimassaoloLoppu'])) {}
-
     try {
       $item = [
         'id' => $featureId,

--- a/public/modules/custom/helfi_kymp_content/tests/src/Kernel/MobileNoteDataServiceTest.php
+++ b/public/modules/custom/helfi_kymp_content/tests/src/Kernel/MobileNoteDataServiceTest.php
@@ -136,6 +136,8 @@ class MobileNoteDataServiceTest extends KernelTestBase {
 
     // Verify date conversion.
     $this->assertEquals(strtotime('2026-01-20'), $item['valid_from']);
+    // valid_to should be the date + 25 hours (86400 + 3600 seconds).
+    $this->assertEquals(strtotime('2026-01-21') + 86400 + 3600, $item['valid_to']);
 
     // Verify EPSG:3879 to WGS84 coordinate conversion.
     $coords = $item['geometry']->coordinates[0];
@@ -163,6 +165,8 @@ class MobileNoteDataServiceTest extends KernelTestBase {
           'properties' => [
             'osoite' => 'Test Street 2',
             'merkinSyy' => ['value' => 'Test Reason'],
+            'voimassaoloAlku' => '2026-01-20',
+            'voimassaoloLoppu' => '2026-01-21',
           ],
         ],
       ],

--- a/public/modules/custom/helfi_kymp_content/tests/src/Kernel/MobileNoteDataServiceTest.php
+++ b/public/modules/custom/helfi_kymp_content/tests/src/Kernel/MobileNoteDataServiceTest.php
@@ -134,10 +134,11 @@ class MobileNoteDataServiceTest extends KernelTestBase {
     $this->assertContains('Mannerheimvägen', $item['street_names']);
     $this->assertCount(2, $item['street_names']);
 
-    // Verify date conversion.
-    $this->assertEquals(strtotime('2026-01-20'), $item['valid_from']);
-    // valid_to should be the date + 25 hours (86400 + 3600 seconds).
-    $this->assertEquals(strtotime('2026-01-21') + 86400 + 3600, $item['valid_to']);
+    // Verify date conversion (Europe/Helsinki timezone).
+    $tz = new \DateTimeZone('Europe/Helsinki');
+    $this->assertEquals((new \DateTime('2026-01-20', $tz))->getTimestamp(), $item['valid_from']);
+    // valid_to should be the date + 24 hours (86400 seconds).
+    $this->assertEquals((new \DateTime('2026-01-21', $tz))->getTimestamp() + 86400, $item['valid_to']);
 
     // Verify EPSG:3879 to WGS84 coordinate conversion.
     $coords = $item['geometry']->coordinates[0];

--- a/public/modules/custom/helfi_kymp_content/tests/src/Kernel/MobileNoteDataSourceTest.php
+++ b/public/modules/custom/helfi_kymp_content/tests/src/Kernel/MobileNoteDataSourceTest.php
@@ -99,8 +99,9 @@ class MobileNoteDataSourceTest extends KernelTestBase {
     $this->assertEquals('Test Reason', $item['reason']);
     $this->assertEquals('Extra', $item['additional_text']);
 
-    // Verify date conversion.
-    $this->assertEquals(strtotime('2026-01-20'), $item['valid_from']);
+    // Verify date conversion (Europe/Helsinki timezone).
+    $tz = new \DateTimeZone('Europe/Helsinki');
+    $this->assertEquals((new \DateTime('2026-01-20', $tz))->getTimestamp(), $item['valid_from']);
 
     // Verify EPSG:3879 to WGS84 coordinate conversion.
     $coords = $item['geometry']->coordinates[0];


### PR DESCRIPTION
# [UHF-12774](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12774)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
Valid to from api is only a date. We must assume that the item is valid to the end of the day.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-X-mobilenote-valid-to-bug`
* Ask me for `local.settings.php` with api keys.

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] `drush sapi-c mobilenote_data; drush sapi-rt mobilenote_data; drush sapi-i mobilenote_data`
* [ ] https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/pysakointi/ajoneuvojen-siirrot/ajoneuvojen-siirtokehotukset should contain items that end 1.4.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* 


[UHF-12774]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ