### PR TITLE
UHF-12891: Filter mobilenote data by merkinLaatu = "Informaatiotaulu"

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -13715,16 +13715,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -13778,7 +13778,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -13798,7 +13798,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",

--- a/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
+++ b/public/modules/custom/helfi_kymp_content/src/MobileNoteDataService.php
@@ -124,13 +124,20 @@ class MobileNoteDataService implements LoggerAwareInterface {
       throw new \InvalidArgumentException($e->getMessage(), previous: $e);
     }
 
-    // Return all items that have validity ending in the future.
+    // Return all items where the sign type is "Informaatiotaulu" and
+    // validity ends in the future.
     $filterXml = <<<XML
 <Filter xmlns="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml">
-  <PropertyIsGreaterThanOrEqualTo>
-    <PropertyName>voimassaoloLoppu</PropertyName>
-    <Literal>{$minDate}</Literal>
-  </PropertyIsGreaterThanOrEqualTo>
+  <And>
+    <PropertyIsGreaterThanOrEqualTo>
+      <PropertyName>voimassaoloLoppu</PropertyName>
+      <Literal>{$minDate}</Literal>
+    </PropertyIsGreaterThanOrEqualTo>
+    <PropertyIsEqualTo>
+      <PropertyName>merkinLaatu</PropertyName>
+      <Literal>Informaatiotaulu</Literal>
+    </PropertyIsEqualTo>
+  </And>
 </Filter>
 XML;
 


### PR DESCRIPTION
# [UHF-12891](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12891)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->

Kymp wants to filter mobilenote items with merkinLaatu = "Informaatiotaulu". Other types in mobilenote contain invalid data and should not be displayed here:

<img width="800" height="392" alt="image" src="https://github.com/user-attachments/assets/e5cefe59-65ff-47ad-bfe7-0245a6e7d790" />

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12891`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Run `drush cron; drush sapi-i mobilenote_data`
* [ ] Run `drush sapi-s`, mobilenote_data index should have around 300 elements (296 currently). 
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* 


[UHF-12891]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ